### PR TITLE
Update CDS Hooks request processing to use PlanDefinition library

### DIFF
--- a/src/main/java/org/opencds/cqf/cds/CarePlanToCdsCard.java
+++ b/src/main/java/org/opencds/cqf/cds/CarePlanToCdsCard.java
@@ -87,31 +87,34 @@ public class CarePlanToCdsCard {
                 }
 
                 // suggestions
-                // TODO - uuid
-                boolean hasSuggestions = false;
-                CdsCard.Suggestions suggestions = new CdsCard.Suggestions();
-                CdsCard.Suggestions.Action actions = new CdsCard.Suggestions.Action();
-                if (action.hasLabel()) {
-                    suggestions.setLabel(action.getLabel());
-                    hasSuggestions = true;
+                if (action.hasType() && !"fire-event".equals(action.getType().getCode())) {
+	                // TODO - uuid
+	                boolean hasSuggestions = false;
+	                CdsCard.Suggestions suggestions = new CdsCard.Suggestions();
+	                CdsCard.Suggestions.Action actions = new CdsCard.Suggestions.Action();
+	                if (action.hasLabel()) {
+	                    suggestions.setLabel(action.getLabel());
+	                    hasSuggestions = true;
+	                }
+	                if (action.hasDescription()) {
+	                    actions.setDescription(action.getDescription());
+	                    hasSuggestions = true;
+	                }
+	                if (action.hasType()) {
+	                    String code = action.getType().getCode();
+	                    actions.setType(CdsCard.Suggestions.Action.ActionType.valueOf(code.equals("remove") ? "delete" : code));
+	                    hasSuggestions = true;
+	                }
+	                if (action.hasResource()) {
+	                    actions.setResource(action.getResourceTarget());
+	                    hasSuggestions = true;
+	                }
+	                if (hasSuggestions) {
+	                    suggestions.addAction(actions);
+	                    card.addSuggestion(suggestions);
+	                }
                 }
-                if (action.hasDescription()) {
-                    actions.setDescription(action.getDescription());
-                    hasSuggestions = true;
-                }
-                if (action.hasType()) {
-                    String code = action.getType().getCode();
-                    actions.setType(CdsCard.Suggestions.Action.ActionType.valueOf(code.equals("remove") ? "delete" : code));
-                    hasSuggestions = true;
-                }
-                if (action.hasResource()) {
-                    actions.setResource(action.getResourceTarget());
-                    hasSuggestions = true;
-                }
-                if (hasSuggestions) {
-                    suggestions.addAction(actions);
-                    card.addSuggestion(suggestions);
-                }
+                
                 cards.add(card);
             }
         }

--- a/src/main/java/org/opencds/cqf/cds/CdsCard.java
+++ b/src/main/java/org/opencds/cqf/cds/CdsCard.java
@@ -370,7 +370,8 @@ public class CdsCard {
         JsonObject card = new JsonObject();
 
         card.addProperty("summary", getSummary());
-        card.addProperty("indicator", getIndicator().code);
+        IndicatorCode indicatorCode = hasIndicator() ? getIndicator() : IndicatorCode.INFO;
+        card.addProperty("indicator", indicatorCode.code);
         if (hasDetail()) {
             card.addProperty("detail", getDetail());
         }
@@ -398,8 +399,12 @@ public class CdsCard {
                     JsonArray actionArray = new JsonArray();
                     for (Suggestions.Action action : suggestion.getActions()) {
                         JsonObject actionObj = new JsonObject();
-                        actionObj.addProperty("type", action.getType().toString());
-                        actionObj.addProperty("description", action.getDescription());
+                        if (action.hasType()) {
+                        	actionObj.addProperty("type", action.getType().toString());
+                        }
+                        if (action.hasDescription()) {
+                        	actionObj.addProperty("description", action.getDescription());
+                        }
                         if (action.hasResource()) {
                             JsonElement res = new JsonParser().parse(FhirContext.forDstu3().newJsonParser().setPrettyPrint(true).encodeResourceToString(action.getResource()));
                             actionObj.add("resource", res);

--- a/src/main/java/org/opencds/cqf/cds/PatientViewProcessor.java
+++ b/src/main/java/org/opencds/cqf/cds/PatientViewProcessor.java
@@ -2,7 +2,6 @@ package org.opencds.cqf.cds;
 
 import ca.uhn.fhir.jpa.rp.dstu3.LibraryResourceProvider;
 import org.cqframework.cql.elm.execution.Library;
-import org.hl7.fhir.dstu3.model.PlanDefinition;
 import org.opencds.cqf.cql.data.fhir.BaseFhirDataProvider;
 import org.opencds.cqf.cql.data.fhir.FhirDataProviderStu3;
 import org.opencds.cqf.cql.execution.Context;
@@ -20,16 +19,22 @@ public class PatientViewProcessor extends CdsRequestProcessor {
 
     @Override
     public List<CdsCard> process() {
-        // TODO - need a better way to determine library id
-        Library library = providers.getLibraryLoader().load(new org.cqframework.cql.elm.execution.VersionedIdentifier().withId("patient-view"));
+        Context executionContext = planDefinitionResourceProvider.createExecutionContext(request);
+        
+        // TODO - temporary, until all unit tests and examples are modified to not expect this default library name
+        if (executionContext  == null) {
+            Library library = providers.getLibraryLoader().load(new org.cqframework.cql.elm.execution.VersionedIdentifier().withId("patient-view"));
+            if (library != null) {
+	        	executionContext = new Context(library);
+	        	executionContext.registerLibraryLoader(providers.getLibraryLoader());
+            }
+        }
 
         BaseFhirDataProvider dstu3Provider = new FhirDataProviderStu3().setEndpoint(request.getFhirServer());
         // TODO - assuming terminology service is same as data provider - not a great assumption...
         dstu3Provider.setTerminologyProvider(new FhirTerminologyProvider().withEndpoint(request.getFhirServer()));
         dstu3Provider.setExpandValueSets(true);
 
-        Context executionContext = new Context(library);
-        executionContext.registerLibraryLoader(providers.getLibraryLoader());
         executionContext.registerDataProvider("http://hl7.org/fhir", dstu3Provider);
         executionContext.registerTerminologyProvider(dstu3Provider.getTerminologyProvider());
         executionContext.setContextValue("Patient", request.getContextProperty("patientId"));


### PR DESCRIPTION
The CDS Hooks request processors have hard-coded library names, e.g. "patient-view" that prevents including more than one patient-view hook on the entire FHIR server.  The request hook processors should retrieve libraries referenced from the PlanDefinition.

Copied block of code from FHIRMeasureResourceProvider to be included in a helper method in FHIRPlanDefinitionResourceProcessor.  Updated PatientViewProcessor and tested successfully.  If this approach is acceptable, the other two CDS request processors should be updated similarly.

Also fixed a few issues that prevented basic info card CDS Hook processors without nested suggestions.