### PR TITLE
Valueset cache operation

### DIFF
--- a/src/main/java/org/opencds/cqf/exceptions/Helper.java
+++ b/src/main/java/org/opencds/cqf/exceptions/Helper.java
@@ -1,0 +1,18 @@
+package org.opencds.cqf.exceptions;
+
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
+
+public class Helper {
+
+    public static OperationOutcome createErrorOutcome(String display) {
+        Coding code = new Coding().setDisplay(display);
+        return new OperationOutcome().addIssue(
+                new OperationOutcome.OperationOutcomeIssueComponent()
+                        .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+                        .setCode(OperationOutcome.IssueType.PROCESSING)
+                        .setDetails(new CodeableConcept().addCoding(code))
+        );
+    }
+}

--- a/src/main/java/org/opencds/cqf/providers/FHIREndpointProvider.java
+++ b/src/main/java/org/opencds/cqf/providers/FHIREndpointProvider.java
@@ -79,7 +79,7 @@ public class FHIREndpointProvider extends EndpointResourceProvider {
         }
     }
 
-    private ValueSet cleanExpandedValueSet(ValueSet expandedValueSet) {
+    private ValueSet getCachedValueSet(ValueSet expandedValueSet) {
         ValueSet clean = expandedValueSet.copy().setExpansion(null);
 
         Map<String, ValueSet.ConceptSetComponent> concepts = new HashMap<>();
@@ -132,7 +132,7 @@ public class FHIREndpointProvider extends EndpointResourceProvider {
         }
 
         if (expand) {
-            return cleanExpandedValueSet(
+            return getCachedValueSet(
                     client
                             .operation()
                             .onInstance(new IdType("ValueSet", valuesetId))

--- a/src/main/java/org/opencds/cqf/providers/FHIREndpointProvider.java
+++ b/src/main/java/org/opencds/cqf/providers/FHIREndpointProvider.java
@@ -120,12 +120,12 @@ public class FHIREndpointProvider extends EndpointResourceProvider {
     }
 
     private ValueSet resolveValueSet(IGenericClient client, String valuesetId) {
-        ValueSet valueSet = client.fetchResourceFromUrl(ValueSet.class, client.getServerBase() + "/ValueSet/" + valuesetId);//.read().resource(ValueSet.class).withId(valuesetId).execute();
+        ValueSet valueSet = client.fetchResourceFromUrl(ValueSet.class, client.getServerBase() + "/ValueSet/" + valuesetId);
 
         boolean expand = false;
         if (valueSet.hasCompose()) {
             for (ValueSet.ConceptSetComponent component : valueSet.getCompose().getInclude()) {
-                if (component.hasValueSet()) {
+                if (!component.hasConcept() || component.getConcept() == null) {
                     expand = true;
                 }
             }

--- a/src/main/java/org/opencds/cqf/providers/FHIREndpointProvider.java
+++ b/src/main/java/org/opencds/cqf/providers/FHIREndpointProvider.java
@@ -1,0 +1,149 @@
+package org.opencds.cqf.providers;
+
+import ca.uhn.fhir.jpa.dao.IFhirSystemDao;
+import ca.uhn.fhir.jpa.rp.dstu3.EndpointResourceProvider;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OptionalParam;
+import ca.uhn.fhir.rest.annotation.RequiredParam;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.client.interceptor.BasicAuthInterceptor;
+import ca.uhn.fhir.rest.param.StringAndListParam;
+import ca.uhn.fhir.rest.param.StringOrListParam;
+import ca.uhn.fhir.rest.param.StringParam;
+import org.hl7.fhir.dstu3.model.*;
+import org.opencds.cqf.exceptions.Helper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FHIREndpointProvider extends EndpointResourceProvider {
+
+    private JpaDataProvider provider;
+    private IFhirSystemDao systemDao;
+
+    public FHIREndpointProvider(JpaDataProvider provider, IFhirSystemDao systemDao) {
+        this.provider = provider;
+        this.systemDao = systemDao;
+    }
+
+    @Operation(name="cache-valuesets", idempotent = true)
+    public Resource cacheValuesets(
+            RequestDetails details,
+            @IdParam IdType theId,
+            @RequiredParam(name="valuesets") StringAndListParam valuesets,
+            @OptionalParam(name="user") String userName,
+            @OptionalParam(name="pass") String password
+    ) {
+
+        Endpoint endpoint = this.getDao().read(theId);
+
+        if (endpoint == null) {
+            return Helper.createErrorOutcome("Could not find Endpoint/" + theId);
+        }
+
+        provider.setEndpoint(endpoint.getAddress());
+        provider.getFhirContext().getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+        IGenericClient client = provider.getFhirClient();
+
+        if (userName != null || password != null) {
+            if (userName == null) {
+                Helper.createErrorOutcome("Password was provided, but not a user name.");
+            }
+            else if (password == null) {
+                Helper.createErrorOutcome("User name was provided, but not a password.");
+            }
+
+            BasicAuthInterceptor basicAuth = new BasicAuthInterceptor(userName, password);
+            client.registerInterceptor(basicAuth);
+
+            // TODO - more advanced security like bearer tokens, etc...
+        }
+
+        try {
+            Bundle bundleToPost = new Bundle();
+            for (StringOrListParam params : valuesets.getValuesAsQueryTokens()) {
+                for (StringParam valuesetId : params.getValuesAsQueryTokens()) {
+                    bundleToPost.addEntry()
+                            .setRequest(new Bundle.BundleEntryRequestComponent().setMethod(Bundle.HTTPVerb.PUT).setUrl("ValueSet/" + valuesetId.getValue()))
+                            .setResource(resolveValueSet(client, valuesetId.getValue()));
+                }
+            }
+
+            return (Resource) systemDao.transaction(details, bundleToPost);
+        } catch (Exception e) {
+            return Helper.createErrorOutcome(e.getMessage());
+        }
+    }
+
+    private ValueSet cleanExpandedValueSet(ValueSet expandedValueSet) {
+        ValueSet clean = expandedValueSet.copy().setExpansion(null);
+
+        Map<String, ValueSet.ConceptSetComponent> concepts = new HashMap<>();
+        for (ValueSet.ValueSetExpansionContainsComponent expansion : expandedValueSet.getExpansion().getContains())
+        {
+            if (!expansion.hasSystem()) {
+                continue;
+            }
+
+            if (concepts.containsKey(expansion.getSystem())) {
+                concepts.get(expansion.getSystem())
+                        .addConcept(
+                                new ValueSet.ConceptReferenceComponent()
+                                        .setCode(expansion.hasCode() ? expansion.getCode() : null)
+                                        .setDisplay(expansion.hasDisplay() ? expansion.getDisplay() : null)
+                        );
+            }
+
+            else {
+                concepts.put(
+                        expansion.getSystem(),
+                        new ValueSet.ConceptSetComponent().setSystem(expansion.getSystem())
+                                .addConcept(
+                                        new ValueSet.ConceptReferenceComponent()
+                                                .setCode(expansion.hasCode() ? expansion.getCode() : null)
+                                                .setDisplay(expansion.hasDisplay() ? expansion.getDisplay() : null)
+                                )
+                );
+            }
+        }
+
+        clean.setCompose(
+                new ValueSet.ValueSetComposeComponent()
+                        .setInclude(new ArrayList<>(concepts.values()))
+        );
+
+        return clean;
+    }
+
+    private ValueSet resolveValueSet(IGenericClient client, String valuesetId) {
+        ValueSet valueSet = client.fetchResourceFromUrl(ValueSet.class, client.getServerBase() + "/ValueSet/" + valuesetId);//.read().resource(ValueSet.class).withId(valuesetId).execute();
+
+        boolean expand = false;
+        if (valueSet.hasCompose()) {
+            for (ValueSet.ConceptSetComponent component : valueSet.getCompose().getInclude()) {
+                if (component.hasValueSet()) {
+                    expand = true;
+                }
+            }
+        }
+
+        if (expand) {
+            return cleanExpandedValueSet(
+                    client
+                            .operation()
+                            .onInstance(new IdType("ValueSet", valuesetId))
+                            .named("$expand")
+                            .withNoParameters(Parameters.class)
+                            .returnResourceType(ValueSet.class)
+                            .execute()
+            );
+        }
+
+        valueSet.setVersion(valueSet.getVersion() + "-cache");
+        return valueSet;
+    }
+}

--- a/src/main/java/org/opencds/cqf/providers/FHIRMeasureResourceProvider.java
+++ b/src/main/java/org/opencds/cqf/providers/FHIRMeasureResourceProvider.java
@@ -1,17 +1,13 @@
 package org.opencds.cqf.providers;
 
-import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.jpa.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.dao.SearchParameterMap;
-import ca.uhn.fhir.jpa.dao.dstu3.FhirSystemDaoDstu3;
 import ca.uhn.fhir.jpa.rp.dstu3.LibraryResourceProvider;
 import ca.uhn.fhir.jpa.rp.dstu3.MeasureResourceProvider;
 import ca.uhn.fhir.rest.annotation.*;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.client.interceptor.BearerTokenAuthInterceptor;
 import ca.uhn.fhir.rest.param.*;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.cqframework.cql.cql2elm.LibraryManager;
@@ -22,7 +18,6 @@ import org.cqframework.cql.elm.execution.VersionedIdentifier;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IAnyResource;
-import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.opencds.cqf.config.STU3LibraryLoader;

--- a/src/main/java/org/opencds/cqf/servlet/BaseServlet.java
+++ b/src/main/java/org/opencds/cqf/servlet/BaseServlet.java
@@ -333,6 +333,20 @@ public class BaseServlet extends RestfulServer {
         }
 
         register(bulkDataGroupProvider, provider.getCollectionProviders());
+
+        // Endpoint processing
+        FHIREndpointProvider endpointProvider = new FHIREndpointProvider(provider, systemDao);
+        EndpointResourceProvider jpaEndpointProvider = (EndpointResourceProvider) provider.resolveResourceProvider("Endpoint");
+        endpointProvider.setDao(jpaEndpointProvider.getDao());
+        endpointProvider.setContext(jpaEndpointProvider.getContext());
+
+        try {
+            unregister(jpaEndpointProvider, provider.getCollectionProviders());
+        } catch (Exception e) {
+            throw new ServletException("Unable to unregister provider: " + e.getMessage());
+        }
+
+        register(endpointProvider, provider.getCollectionProviders());
     }
 
     private void register(IResourceProvider provider, Collection<IResourceProvider> providers) {


### PR DESCRIPTION
I made a few changes to the proposed operation. During the design discussion we had proposed an operation on a ValueSet instance, but this is actually an operation on an Endpoint instance (if we were to ship one of the ValueSets stored within the CQF Ruler to another server, then that would be an operation on a ValueSet). Therefore, I changed this operation to Endpoint/$cache-valusets and allow for a comma-delimited list of ValueSet ids as one of the parameters.

Example:
`[base]/Endpoint/example-apelon/$cache-valuesets?valuesets=2.16.840.1.114222.4.11.836,2.16.840.1.113883.3.464.1003.108.12.1011&user=user&pass=pass`

Endpoint/example-apelon:
```
{
	"resourceType": "Endpoint",
	"id": "example-apelon",
	"status": "active",
	"connectionType": {
		"system": "http://hl7.org/fhir/endpoint-connection-type",
		"code": "hl7-fhir-rest"
	},
	"payloadType": [
		{
			"coding": [
				{
					"code": "ValueSet"
				}
			]
		}
    ],
    "address": "http://fhir.ext.apelon.com:7080/dtsserverws/fhir"
}
```

Currently only basic auth is supported. It would not be difficult to plugin better auth, but I don't have a good way to test right now.

