### PR TITLE
Added code to set timezone to UTC to fix boundary and display issues in $evaluate-measure

### DIFF
--- a/common/src/main/java/org/opencds/cqf/common/helpers/DateHelper.java
+++ b/common/src/main/java/org/opencds/cqf/common/helpers/DateHelper.java
@@ -1,6 +1,10 @@
 package org.opencds.cqf.common.helpers;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
 
 public class DateHelper {
 

--- a/common/src/main/java/org/opencds/cqf/common/helpers/DateHelper.java
+++ b/common/src/main/java/org/opencds/cqf/common/helpers/DateHelper.java
@@ -1,9 +1,6 @@
 package org.opencds.cqf.common.helpers;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 public class DateHelper {
 
@@ -23,6 +20,7 @@ public class DateHelper {
         // for now support dates up to day precision
         Calendar calendar = Calendar.getInstance();
         calendar.clear();
+        calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         calendar.set(Calendar.YEAR, dateVals.get(0));
         if (dateVals.size() > 1) {
             // java.util.Date months are zero based, hence the negative 1 -- 2014-01 == February 2014


### PR DESCRIPTION
This fixes boundary and display issues with dates when the JVM timezone is not defaulted to 'UTC'.

**To test:**
- Start cqf-ruler on a machine with a default timezone other than UTC. I used US Eastern.
- Upload attached measure with config data.
[EXM124-FHIR3.zip](https://github.com/DBCG/cqf-ruler/files/4031337/EXM124-FHIR3.zip)
- ```curl -v  "http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm124-FHIR3/%24evaluate-measure?patient=98ce13e-450b-43ca-9fbe-08b05999532b-1&periodStart=2019-01-01&periodEnd=2019-12-31" -H "Content-Type: application/json"```

**Boundary issues:** 
**Before:**
```
{
          "code": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
                "code": "numerator",
                "display": "Numerator"
              }
            ]
          },
          "count": 0
        },
```
**After:**
```
{
          "code": {
            "coding": [
              {
                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
                "code": "numerator",
                "display": "Numerator"
              }
            ]
          },
          "count": 1
        },
```
**Display Issues:** 
**Before:**
```
“period”: {
    “start”: “2019-01-01T05:00:00+00:00”,
    “end”: “2019-12-31T05:00:00+00:00”
  },
```
**After:** 
```
  "period": {
    "start": "2019-01-01T00:00:00+00:00",
    "end": "2019-12-31T00:00:00+00:00"
  }
```

