### PR TITLE
Fix fhirtester webpage for dstu3

### DIFF
--- a/cqf-ruler-dstu3/src/main/webapp/WEB-INF/web.xml
+++ b/cqf-ruler-dstu3/src/main/webapp/WEB-INF/web.xml
@@ -51,7 +51,7 @@
         </init-param>
         <init-param>
             <param-name>contextConfigLocation</param-name>
-            <param-value>org.opencds.cqf.config.FhirTesterConfig</param-value>
+            <param-value>org.opencds.cqf.common.config.FhirTesterConfig</param-value>
         </init-param>
         <load-on-startup>2</load-on-startup>
     </servlet>


### PR DESCRIPTION
Fixes the config so that the FHIR Tester webpage shows correctly when running `mvn jetty:run -am --projects cqf-ruler-dstu3` and navigating to `http://localhost:8080/cqf-ruler-dstu3/`