### PR TITLE
Related artifacts in the measure resource are now cleared completely …

### DIFF
--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/providers/MeasureOperationsProvider.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/providers/MeasureOperationsProvider.java
@@ -95,6 +95,9 @@ public class MeasureOperationsProvider {
     public MethodOutcome refreshGeneratedContent(HttpServletRequest theRequest, RequestDetails theRequestDetails,
             @IdParam IdType theId) {
         Measure theResource = this.measureResourceProvider.getDao().read(theId);
+
+        theResource.getRelatedArtifact().removeIf(relatedArtifact -> relatedArtifact.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON));
+
         CqfMeasure cqfMeasure = this.dataRequirementsProvider.createCqfMeasure(theResource, this.libraryResolutionProvider);
 
         // Ensure All Related Artifacts for all referenced Libraries

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <properties>
         <version.major>0</version.major>
         <version.minor>1</version.minor>
-        <version.patch>14.2</version.patch>
+        <version.patch>14.3</version.patch>
         <!-- NOTE: Building under the release profile automatically drops the -SNAPSHOT extension -->
         <revision>${version.major}.${version.minor}.${version.patch}-SNAPSHOT</revision>
 

--- a/r4/src/main/java/org/opencds/cqf/r4/providers/MeasureOperationsProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/MeasureOperationsProvider.java
@@ -93,6 +93,9 @@ public class MeasureOperationsProvider {
     public MethodOutcome refreshGeneratedContent(HttpServletRequest theRequest, RequestDetails theRequestDetails,
             @IdParam IdType theId) {
         Measure theResource = this.measureResourceProvider.getDao().read(theId);
+
+        theResource.getRelatedArtifact().clear();
+
         CqfMeasure cqfMeasure = this.dataRequirementsProvider.createCqfMeasure(theResource, this.libraryResolutionProvider);
 
         // Ensure All Related Artifacts for all referenced Libraries

--- a/r4/src/main/java/org/opencds/cqf/r4/providers/MeasureOperationsProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/MeasureOperationsProvider.java
@@ -94,7 +94,7 @@ public class MeasureOperationsProvider {
             @IdParam IdType theId) {
         Measure theResource = this.measureResourceProvider.getDao().read(theId);
 
-        theResource.getRelatedArtifact().clear();
+        theResource.getRelatedArtifact().removeIf(relatedArtifact -> relatedArtifact.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON));
 
         CqfMeasure cqfMeasure = this.dataRequirementsProvider.createCqfMeasure(theResource, this.libraryResolutionProvider);
 


### PR DESCRIPTION
…during refreshGeneratedContent to avoid leaving artifacts that are no longer referenced.