### PR TITLE
Improvement to Dockerfile to build app as part of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM maven:latest as builder
+
+RUN mkdir /build
+WORKDIR /build
+COPY . .
+RUN mvn package
+
 FROM jetty:9-jre11
 
 USER jetty:jetty
@@ -8,8 +15,8 @@ RUN mkdir -p /var/lib/jetty/target
 #Default config directory
 RUN mkdir -p /var/lib/jetty/webapps/config
 
-COPY --chown=jetty:jetty ./cqf-ruler-dstu3/target/cqf-ruler-dstu3.war /var/lib/jetty/webapps/cqf-ruler-dstu3.war
-COPY --chown=jetty:jetty ./cqf-ruler-r4/target/cqf-ruler-r4.war /var/lib/jetty/webapps/cqf-ruler-r4.war
+COPY --chown=jetty:jetty --from=builder /build/cqf-ruler-dstu3/target/cqf-ruler-dstu3.war /var/lib/jetty/webapps/cqf-ruler-dstu3.war
+COPY --chown=jetty:jetty --from=builder /build/cqf-ruler-r4/target/cqf-ruler-r4.war /var/lib/jetty/webapps/cqf-ruler-r4.war
 EXPOSE 8080
 
 ENV SERVER_ADDRESS_DSTU3="http://localhost:8080/cqf-ruler-dstu3/fhir"
@@ -18,7 +25,6 @@ ENV JAVA_OPTIONS=""
 
 COPY --chown=jetty:jetty ./scripts/docker-entrypoint-override.sh /docker-entrypoint-override.sh
 ENTRYPOINT [ "/docker-entrypoint-override.sh" ]
-
 
 # FROM runner as test-data
 # COPY --chown=jetty:jetty ./target/jpaserver_derby_files  /var/lib/jetty/target/jpaserver_derby_files


### PR DESCRIPTION
Improvement to Dockerfile to build the project as part of the docker build process, instead of requiring that the individual who runs `docker build` have the project built with maven on the host machine first.