### PR TITLE
Restore terminology and model resolver caches

### DIFF
--- a/common/src/main/java/org/opencds/cqf/common/providers/CacheAwareTerminologyProvider.java
+++ b/common/src/main/java/org/opencds/cqf/common/providers/CacheAwareTerminologyProvider.java
@@ -1,0 +1,56 @@
+package org.opencds.cqf.common.providers;
+
+import java.util.Map;
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+
+public class CacheAwareTerminologyProvider implements TerminologyProvider {
+
+    private TerminologyProvider innerTerminologyProvider;
+
+    private Map<String, Iterable<Code>> globalCodeCacheByUrl;
+
+    public CacheAwareTerminologyProvider(Map<String, Iterable<Code>> globalCodeCacheByUrl, TerminologyProvider innerTerminologyProvider) {
+        this.globalCodeCacheByUrl = globalCodeCacheByUrl;
+        this.innerTerminologyProvider = innerTerminologyProvider;
+    }
+
+    @Override
+    public boolean in(Code code, ValueSetInfo valueSet) {
+        Iterable<Code> codes = this.expand(valueSet);
+        if (codes == null) {
+            return false;
+        }
+
+        for (Code c : codes) {
+            if (c.equivalent(code)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public Iterable<Code> expand(ValueSetInfo valueSet) {
+        if (this.globalCodeCacheByUrl.containsKey(valueSet.getId())) {
+            return this.globalCodeCacheByUrl.get(valueSet.getId());
+        }
+
+        Iterable<Code> codes = this.innerTerminologyProvider.expand(valueSet);
+
+        if (codes != null) {
+            this.globalCodeCacheByUrl.put(valueSet.getId(), codes);
+        }
+
+        return codes;
+    }
+
+    @Override
+    public Code lookup(Code code, CodeSystemInfo codeSystem) {
+        return this.innerTerminologyProvider.lookup(code, codeSystem);
+    }
+    
+}

--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/ProviderFactory.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/ProviderFactory.java
@@ -8,13 +8,14 @@ import org.opencds.cqf.common.providers.Dstu3ApelonFhirTerminologyProvider;
 import org.opencds.cqf.common.retrieve.JpaFhirRetrieveProvider;
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
 import org.opencds.cqf.cql.engine.data.DataProvider;
-import org.opencds.cqf.cql.engine.fhir.model.Dstu3FhirModelResolver;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.fhir.terminology.Dstu3FhirTerminologyProvider;
+import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.springframework.stereotype.Component;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
@@ -29,12 +30,15 @@ public class ProviderFactory implements EvaluationProviderFactory {
     FhirContext fhirContext;
     ISearchParamRegistry searchParamRegistry;
 
+    ModelResolver modelResolver;
+
     @Inject
     public ProviderFactory(FhirContext fhirContext, DaoRegistry registry,
-            TerminologyProvider defaultTerminologyProvider) {
+            TerminologyProvider defaultTerminologyProvider, ModelResolver modelResolver) {
         this.defaultTerminologyProvider = defaultTerminologyProvider;
         this.registry = registry;
         this.fhirContext = fhirContext;
+        this.modelResolver = modelResolver;
     }
 
     public DataProvider createDataProvider(String model, String version) {
@@ -48,7 +52,6 @@ public class ProviderFactory implements EvaluationProviderFactory {
 
     public DataProvider createDataProvider(String model, String version, TerminologyProvider terminologyProvider) {
         if (model.equals("FHIR") && version.startsWith("3")) {
-            Dstu3FhirModelResolver modelResolver = new Dstu3FhirModelResolver();
             JpaFhirRetrieveProvider retrieveProvider = new JpaFhirRetrieveProvider(this.registry,
                     new SearchParameterResolver(this.fhirContext));
             retrieveProvider.setTerminologyProvider(terminologyProvider);
@@ -64,7 +67,7 @@ public class ProviderFactory implements EvaluationProviderFactory {
     public TerminologyProvider createTerminologyProvider(String model, String version, String url, String user,
             String pass) {
         if (url != null && !url.isEmpty()) {
-            IGenericClient client = ClientHelper.getClient(FhirContext.forDstu3(), url, user, pass);
+            IGenericClient client = ClientHelper.getClient(FhirContext.forCached(FhirVersionEnum.DSTU3), url, user, pass);
             if (url.contains("apelon.com")) {
                 return new Dstu3ApelonFhirTerminologyProvider(client);
             }

--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/providers/HQMFProvider.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/providers/HQMFProvider.java
@@ -51,6 +51,7 @@ import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.parser.IParser;
 
 @Component
@@ -671,7 +672,7 @@ public class HQMFProvider {
             DataRequirementsProvider dataRequirementsProvider = new DataRequirementsProvider();
             NarrativeProvider narrativeProvider = new NarrativeProvider(pathToProp.toUri().toString());;
         
-            FhirContext context = FhirContext.forDstu3();
+            FhirContext context = FhirContext.forCached(FhirVersionEnum.DSTU3);
 
             //IParser parser = pathToMeasure.toString().endsWith("json") ? context.newJsonParser() : context.newXmlParser();
 

--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/servlet/CdsHooksServlet.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/servlet/CdsHooksServlet.java
@@ -41,12 +41,12 @@ import org.opencds.cqf.common.helpers.LoggingHelper;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.common.retrieve.JpaFhirRetrieveProvider;
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
-import org.opencds.cqf.cql.engine.debug.DebugMap;
 import org.opencds.cqf.cql.engine.exception.CqlException;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import org.opencds.cqf.cql.engine.fhir.exception.DataProviderException;
-import org.opencds.cqf.cql.engine.fhir.model.Dstu3FhirModelResolver;
+import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.dstu3.helpers.LibraryHelper;
 import org.opencds.cqf.dstu3.providers.PlanDefinitionApplyProvider;
 import org.slf4j.Logger;
@@ -55,7 +55,6 @@ import org.springframework.context.ApplicationContext;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import ca.uhn.fhir.cql.dstu3.provider.JpaTerminologyProvider;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 
 @WebServlet(name = "cds-services")
@@ -70,9 +69,11 @@ public class CdsHooksServlet extends HttpServlet {
 
     private JpaFhirRetrieveProvider fhirRetrieveProvider;
 
-    private JpaTerminologyProvider jpaTerminologyProvider;
+    private TerminologyProvider serverTerminologyProvider;
 
     private ProviderConfiguration providerConfiguration;
+
+    private ModelResolver modelResolver;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -85,7 +86,8 @@ public class CdsHooksServlet extends HttpServlet {
         this.planDefinitionProvider = appCtx.getBean(PlanDefinitionApplyProvider.class);
         this.libraryResolutionProvider = (LibraryResolutionProvider<org.hl7.fhir.dstu3.model.Library>)appCtx.getBean(LibraryResolutionProvider.class);
         this.fhirRetrieveProvider = appCtx.getBean(JpaFhirRetrieveProvider.class);
-        this.jpaTerminologyProvider = appCtx.getBean(JpaTerminologyProvider.class);
+        this.serverTerminologyProvider = appCtx.getBean(TerminologyProvider.class);
+        this.modelResolver = appCtx.getBean(ModelResolver.class);
     }
 
     protected ProviderConfiguration getProviderConfiguration() {
@@ -170,8 +172,7 @@ public class CdsHooksServlet extends HttpServlet {
             LibraryLoader libraryLoader = LibraryHelper.createLibraryLoader(libraryResolutionProvider);
             Library library = LibraryHelper.resolvePrimaryLibrary(planDefinition, libraryLoader, libraryResolutionProvider);
 
-            Dstu3FhirModelResolver resolver = new Dstu3FhirModelResolver();
-            CompositeDataProvider provider = new CompositeDataProvider(resolver, fhirRetrieveProvider);
+            CompositeDataProvider provider = new CompositeDataProvider(this.modelResolver, fhirRetrieveProvider);
 
             Context context = new Context(library);
 
@@ -179,13 +180,13 @@ public class CdsHooksServlet extends HttpServlet {
 
             context.registerDataProvider("http://hl7.org/fhir", provider); // TODO make sure tooling handles remote
                                                                            // provider case
-            context.registerTerminologyProvider(jpaTerminologyProvider);
+            context.registerTerminologyProvider(serverTerminologyProvider);
             context.registerLibraryLoader(libraryLoader);
             context.setContextValue("Patient", hook.getRequest().getContext().getPatientId().replace("Patient/", ""));
             context.setExpressionCaching(true);
 
             EvaluationContext<PlanDefinition> evaluationContext = new Stu3EvaluationContext(hook, version, FhirContext.forDstu3().newRestfulGenericClient(baseUrl),
-                jpaTerminologyProvider, context, library,
+                serverTerminologyProvider, context, library,
                 planDefinition, this.getProviderConfiguration());
 
             this.setAccessControlHeaders(response);
@@ -289,7 +290,7 @@ public class CdsHooksServlet extends HttpServlet {
 
     private JsonObject getServices() {
         DiscoveryResolutionStu3 discoveryResolutionStu3 = new DiscoveryResolutionStu3(
-                FhirContext.forDstu3().newRestfulGenericClient(HapiProperties.getServerAddress()));
+                FhirContext.forCached(FhirVersionEnum.DSTU3).newRestfulGenericClient(HapiProperties.getServerAddress()));
         discoveryResolutionStu3.setMaxUriLength(this.getProviderConfiguration().getMaxUriLength());
         return discoveryResolutionStu3.resolve()
                         .getAsJson();

--- a/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
@@ -12,7 +12,6 @@ import org.opencds.cqf.common.helpers.LoggingHelper;
 import org.opencds.cqf.common.helpers.UsingHelper;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.cql.engine.data.DataProvider;
-import org.opencds.cqf.cql.engine.debug.DebugMap;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import org.opencds.cqf.cql.engine.runtime.DateTime;

--- a/r4/src/main/java/org/opencds/cqf/r4/evaluation/ProviderFactory.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/evaluation/ProviderFactory.java
@@ -8,13 +8,14 @@ import org.opencds.cqf.common.providers.R4ApelonFhirTerminologyProvider;
 import org.opencds.cqf.common.retrieve.JpaFhirRetrieveProvider;
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
 import org.opencds.cqf.cql.engine.data.DataProvider;
-import org.opencds.cqf.cql.engine.fhir.model.R4FhirModelResolver;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.fhir.terminology.R4FhirTerminologyProvider;
+import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.springframework.stereotype.Component;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
@@ -26,13 +27,15 @@ public class ProviderFactory implements EvaluationProviderFactory {
     DaoRegistry registry;
     TerminologyProvider defaultTerminologyProvider;
     FhirContext fhirContext;
+    ModelResolver modelResolver;
 
     @Inject
     public ProviderFactory(FhirContext fhirContext, DaoRegistry registry,
-            TerminologyProvider defaultTerminologyProvider) {
+            TerminologyProvider defaultTerminologyProvider, ModelResolver modelResolver) {
         this.defaultTerminologyProvider = defaultTerminologyProvider;
         this.registry = registry;
         this.fhirContext = fhirContext;
+        this.modelResolver = modelResolver;
     }
 
     public DataProvider createDataProvider(String model, String version) {
@@ -46,7 +49,6 @@ public class ProviderFactory implements EvaluationProviderFactory {
 
     public DataProvider createDataProvider(String model, String version, TerminologyProvider terminologyProvider) {
         if (model.equals("FHIR") && version.startsWith("4")) {
-            R4FhirModelResolver modelResolver = new R4FhirModelResolver();
             JpaFhirRetrieveProvider retrieveProvider = new JpaFhirRetrieveProvider(this.registry,
                     new SearchParameterResolver(this.fhirContext));
             retrieveProvider.setTerminologyProvider(terminologyProvider);
@@ -62,7 +64,7 @@ public class ProviderFactory implements EvaluationProviderFactory {
     public TerminologyProvider createTerminologyProvider(String model, String version, String url, String user,
             String pass) {
         if (url != null && !url.isEmpty()) {
-            IGenericClient client = ClientHelper.getClient(FhirContext.forR4(), url, user, pass);
+            IGenericClient client = ClientHelper.getClient(FhirContext.forCached(FhirVersionEnum.R4), url, user, pass);
             if (url.contains("apelon.com")) {
                 return new R4ApelonFhirTerminologyProvider(client);
             }

--- a/r4/src/main/java/org/opencds/cqf/r4/providers/HQMFProvider.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/providers/HQMFProvider.java
@@ -50,6 +50,7 @@ import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.parser.IParser;
 
 @Component
@@ -673,7 +674,7 @@ public class HQMFProvider {
             NarrativeProvider narrativeProvider = new NarrativeProvider(pathToProp.toUri().toString());
             ;
 
-            FhirContext context = FhirContext.forDstu3();
+            FhirContext context = FhirContext.forCached(FhirVersionEnum.DSTU3);
 
             // IParser parser = pathToMeasure.toString().endsWith("json") ?
             // context.newJsonParser() : context.newXmlParser();

--- a/r4/src/main/java/org/opencds/cqf/r4/servlet/CdsHooksServlet.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/servlet/CdsHooksServlet.java
@@ -41,12 +41,12 @@ import org.opencds.cqf.common.helpers.LoggingHelper;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.common.retrieve.JpaFhirRetrieveProvider;
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;
-import org.opencds.cqf.cql.engine.debug.DebugMap;
 import org.opencds.cqf.cql.engine.exception.CqlException;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import org.opencds.cqf.cql.engine.fhir.exception.DataProviderException;
-import org.opencds.cqf.cql.engine.fhir.model.R4FhirModelResolver;
+import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.r4.helpers.LibraryHelper;
 import org.opencds.cqf.r4.providers.PlanDefinitionApplyProvider;
 import org.slf4j.Logger;
@@ -55,7 +55,6 @@ import org.springframework.context.ApplicationContext;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.FhirVersionEnum;
-import ca.uhn.fhir.cql.r4.provider.JpaTerminologyProvider;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 
 @WebServlet(name = "cds-services")
@@ -70,9 +69,11 @@ public class CdsHooksServlet extends HttpServlet {
 
     private JpaFhirRetrieveProvider fhirRetrieveProvider;
 
-    private JpaTerminologyProvider jpaTerminologyProvider;
+    private TerminologyProvider serverTerminologyProvider;
 
     private ProviderConfiguration providerConfiguration;
+
+    private ModelResolver modelResolver;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -85,7 +86,8 @@ public class CdsHooksServlet extends HttpServlet {
         this.planDefinitionProvider = appCtx.getBean(PlanDefinitionApplyProvider.class);
         this.libraryResolutionProvider = (LibraryResolutionProvider<org.hl7.fhir.r4.model.Library>)appCtx.getBean(LibraryResolutionProvider.class);
         this.fhirRetrieveProvider = appCtx.getBean(JpaFhirRetrieveProvider.class);
-        this.jpaTerminologyProvider = appCtx.getBean(JpaTerminologyProvider.class);
+        this.serverTerminologyProvider = appCtx.getBean(TerminologyProvider.class);
+        this.modelResolver = appCtx.getBean(ModelResolver.class);
     }
 
     protected ProviderConfiguration getProviderConfiguration() {
@@ -174,8 +176,7 @@ public class CdsHooksServlet extends HttpServlet {
             Library library = LibraryHelper.resolvePrimaryLibrary(planDefinition, libraryLoader,
                     libraryResolutionProvider);
 
-            R4FhirModelResolver resolver = new R4FhirModelResolver();
-            CompositeDataProvider provider = new CompositeDataProvider(resolver, fhirRetrieveProvider);
+            CompositeDataProvider provider = new CompositeDataProvider(this.modelResolver, fhirRetrieveProvider);
 
             Context context = new Context(library);
 
@@ -183,13 +184,13 @@ public class CdsHooksServlet extends HttpServlet {
 
             context.registerDataProvider("http://hl7.org/fhir", provider); // TODO make sure tooling handles remote
                                                                            // provider case
-            context.registerTerminologyProvider(jpaTerminologyProvider);
+            context.registerTerminologyProvider(serverTerminologyProvider);
             context.registerLibraryLoader(libraryLoader);
             context.setContextValue("Patient", hook.getRequest().getContext().getPatientId().replace("Patient/", ""));
             context.setExpressionCaching(true);
 
             EvaluationContext<PlanDefinition> evaluationContext = new R4EvaluationContext(hook, version,
-                    FhirContext.forR4().newRestfulGenericClient(baseUrl), jpaTerminologyProvider, context, library,
+                    FhirContext.forCached(FhirVersionEnum.R4).newRestfulGenericClient(baseUrl), serverTerminologyProvider, context, library,
                     planDefinition, this.getProviderConfiguration());
 
             this.setAccessControlHeaders(response);
@@ -295,7 +296,7 @@ public class CdsHooksServlet extends HttpServlet {
 
     private JsonObject getServices() {
         DiscoveryResolutionR4 discoveryResolutionR4 = new DiscoveryResolutionR4(
-                FhirContext.forR4().newRestfulGenericClient(HapiProperties.getServerAddress()));
+            FhirContext.forCached(FhirVersionEnum.R4).newRestfulGenericClient(HapiProperties.getServerAddress()));
         discoveryResolutionR4.setMaxUriLength(this.getProviderConfiguration().getMaxUriLength());
         return discoveryResolutionR4.resolve()
                         .getAsJson();


### PR DESCRIPTION
These changes got lost somewhere along the way:
* Use cached FhirContexts
* Use ModelResolver cache
* Use Terminology cache