### PR TITLE
Feature configurable cql logging

### DIFF
--- a/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
+++ b/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
@@ -11,8 +11,6 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.SearchStyleEnum;
 import ca.uhn.fhir.rest.server.ETagSupportEnum;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HapiProperties {
     static final String ALLOW_EXTERNAL_REFERENCES = "allow_external_references";

--- a/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
+++ b/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
@@ -259,7 +259,7 @@ public class HapiProperties {
     }
 
     public static Boolean getCQLDebugLoggingEnabled() {
-        return HapiProperties.getBooleanProperty(CQL_DEBUG_LOGGING_ENABLED, true);
+        return HapiProperties.getBooleanProperty(CQL_DEBUG_LOGGING_ENABLED, false);
     }
 
     public static String getDataSourceDriver() {

--- a/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
+++ b/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
@@ -11,6 +11,8 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.SearchStyleEnum;
 import ca.uhn.fhir.rest.server.ETagSupportEnum;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HapiProperties {
     static final String ALLOW_EXTERNAL_REFERENCES = "allow_external_references";
@@ -77,7 +79,7 @@ public class HapiProperties {
     static final String CDSHOOKS_FHIRSERVER_SEARCHSTYLE= "cds_hooks.fhirServer.searchStyle";
     static final String CDSHOOKS_PREFETCH_MAXURILENGTH= "cds_hooks.prefetch.maxUriLength";
 
-    static final String CQL_ENABLE_DEBUG_LOGGING = "cql.enable_debug_logging";
+    static final String CQL_DEBUG_LOGGING_ENABLED = "cql.debugLogging.enabled";
 
     private static Properties properties;
 
@@ -258,8 +260,8 @@ public class HapiProperties {
         return HapiProperties.getBooleanProperty(LOGGER_LOG_EXCEPTIONS, true);
     }
 
-    public static Boolean getCQLEnableDebugLogging() {
-        return HapiProperties.getBooleanProperty(CQL_ENABLE_DEBUG_LOGGING, false);
+    public static Boolean getCQLDebugLoggingEnabled() {
+        return HapiProperties.getBooleanProperty(CQL_DEBUG_LOGGING_ENABLED, true);
     }
 
     public static String getDataSourceDriver() {

--- a/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
+++ b/common/src/main/java/org/opencds/cqf/common/config/HapiProperties.java
@@ -77,6 +77,8 @@ public class HapiProperties {
     static final String CDSHOOKS_FHIRSERVER_SEARCHSTYLE= "cds_hooks.fhirServer.searchStyle";
     static final String CDSHOOKS_PREFETCH_MAXURILENGTH= "cds_hooks.prefetch.maxUriLength";
 
+    static final String CQL_ENABLE_DEBUG_LOGGING = "cql.enable_debug_logging";
+
     private static Properties properties;
 
     /*
@@ -254,6 +256,10 @@ public class HapiProperties {
 
     public static Boolean getLoggerLogExceptions() {
         return HapiProperties.getBooleanProperty(LOGGER_LOG_EXCEPTIONS, true);
+    }
+
+    public static Boolean getCQLEnableDebugLogging() {
+        return HapiProperties.getBooleanProperty(CQL_ENABLE_DEBUG_LOGGING, false);
     }
 
     public static String getDataSourceDriver() {

--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/MeasureEvaluationSeed.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/MeasureEvaluationSeed.java
@@ -19,12 +19,8 @@ import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.dstu3.helpers.LibraryHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MeasureEvaluationSeed {
-    private static final Logger logger = LoggerFactory.getLogger(MeasureEvaluationSeed.class);
-
     private Measure measure;
     private Context context;
     private Interval measurementPeriod;

--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/MeasureEvaluationSeed.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/MeasureEvaluationSeed.java
@@ -6,11 +6,13 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.Triple;
 import org.cqframework.cql.elm.execution.Library;
 import org.hl7.fhir.dstu3.model.Measure;
+import org.opencds.cqf.common.config.HapiProperties;
 import org.opencds.cqf.common.evaluation.EvaluationProviderFactory;
 import org.opencds.cqf.common.helpers.DateHelper;
 import org.opencds.cqf.common.helpers.UsingHelper;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.debug.DebugMap;
 import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
@@ -102,5 +104,9 @@ public class MeasureEvaluationSeed {
         }
 
         context.setExpressionCaching(true);
+
+        DebugMap debugMap = new DebugMap();
+        debugMap.setIsLoggingEnabled(HapiProperties.getCQLEnableDebugLogging());
+        context.setDebugMap(debugMap);
     }
 }

--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/MeasureEvaluationSeed.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/evaluation/MeasureEvaluationSeed.java
@@ -19,8 +19,12 @@ import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.dstu3.helpers.LibraryHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MeasureEvaluationSeed {
+    private static final Logger logger = LoggerFactory.getLogger(MeasureEvaluationSeed.class);
+
     private Measure measure;
     private Context context;
     private Interval measurementPeriod;
@@ -106,7 +110,7 @@ public class MeasureEvaluationSeed {
         context.setExpressionCaching(true);
 
         DebugMap debugMap = new DebugMap();
-        debugMap.setIsLoggingEnabled(HapiProperties.getCQLEnableDebugLogging());
+        debugMap.setIsLoggingEnabled(HapiProperties.getCQLDebugLoggingEnabled());
         context.setDebugMap(debugMap);
     }
 }

--- a/dstu3/src/main/java/org/opencds/cqf/dstu3/servlet/CdsHooksServlet.java
+++ b/dstu3/src/main/java/org/opencds/cqf/dstu3/servlet/CdsHooksServlet.java
@@ -157,7 +157,7 @@ public class CdsHooksServlet extends HttpServlet {
             Context context = new Context(library);
 
             DebugMap debugMap = new DebugMap();
-            debugMap.setIsLoggingEnabled(true);
+            debugMap.setIsLoggingEnabled(HapiProperties.getCQLDebugLoggingEnabled());
             context.setDebugMap(debugMap);
 
             context.registerDataProvider("http://hl7.org/fhir", provider); // TODO make sure tooling handles remote

--- a/dstu3/src/main/resources/hapi.properties
+++ b/dstu3/src/main/resources/hapi.properties
@@ -192,4 +192,4 @@ cds_hooks.prefetch.maxUriLength=
 ##################################################
 # CQL Settings
 ##################################################
-cql.enable_debug_logging=true
+cql.debugLogging.enabled=false

--- a/dstu3/src/main/resources/hapi.properties
+++ b/dstu3/src/main/resources/hapi.properties
@@ -188,3 +188,8 @@ cds_hooks.fhirServer.maxCodesPerQuery=
 cds_hooks.fhirServer.expandValueSets=
 cds_hooks.fhirServer.searchStyle=
 cds_hooks.prefetch.maxUriLength=
+
+##################################################
+# CQL Settings
+##################################################
+cql.enable_debug_logging=true

--- a/dstu3/src/main/resources/logback.xml
+++ b/dstu3/src/main/resources/logback.xml
@@ -37,4 +37,8 @@
         <!-- <appender-ref ref="htmlAppender" /> -->
     </root>
 
+    <!-- added DebugUtilities logger to facilitate CQL debug logging without turning on debug logging for everything -->
+    <!-- to enable CQL debug logging, set 'cql.debugLogging.enabled=true' in hapi.properties -->
+    <logger name="org.opencds.cqf.cql.engine.debug.DebugUtilities" level="DEBUG" />
+
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <hapi.version>5.4.1</hapi.version>
         <fhir.core.version>5.4.5</fhir.core.version>
         <cqf-tooling.version>1.3.1-SNAPSHOT</cqf-tooling.version>
-        <cql-engine.version>1.5.1</cql-engine.version>
+        <cql-engine.version>1.5.2-SNAPSHOT</cql-engine.version>
         <cql-evaluator.version>1.2.1-SNAPSHOT</cql-evaluator.version>
         <cqframework.version>1.5.3</cqframework.version>
         <cds-hooks.version>1.3.1-SNAPSHOT</cds-hooks.version>

--- a/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
@@ -19,8 +19,12 @@ import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.r4.helpers.LibraryHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MeasureEvaluationSeed {
+    private static final Logger logger = LoggerFactory.getLogger(MeasureEvaluationSeed.class);
+
     private Measure measure;
     private Context context;
     private Interval measurementPeriod;
@@ -106,7 +110,7 @@ public class MeasureEvaluationSeed {
         context.setExpressionCaching(true);
 
         DebugMap debugMap = new DebugMap();
-        debugMap.setIsLoggingEnabled(HapiProperties.getCQLEnableDebugLogging());
+        debugMap.setIsLoggingEnabled(HapiProperties.getCQLDebugLoggingEnabled());
         context.setDebugMap(debugMap);
     }
 }

--- a/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
@@ -19,12 +19,8 @@ import org.opencds.cqf.cql.engine.runtime.DateTime;
 import org.opencds.cqf.cql.engine.runtime.Interval;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.r4.helpers.LibraryHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MeasureEvaluationSeed {
-    private static final Logger logger = LoggerFactory.getLogger(MeasureEvaluationSeed.class);
-
     private Measure measure;
     private Context context;
     private Interval measurementPeriod;

--- a/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/evaluation/MeasureEvaluationSeed.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.apache.commons.lang3.tuple.Triple;
 import org.cqframework.cql.elm.execution.Library;
 import org.hl7.fhir.r4.model.Measure;
+import org.opencds.cqf.common.config.HapiProperties;
 import org.opencds.cqf.common.evaluation.EvaluationProviderFactory;
 import org.opencds.cqf.common.helpers.DateHelper;
 import org.opencds.cqf.common.helpers.UsingHelper;
@@ -105,7 +106,7 @@ public class MeasureEvaluationSeed {
         context.setExpressionCaching(true);
 
         DebugMap debugMap = new DebugMap();
-        debugMap.setIsLoggingEnabled(true);
+        debugMap.setIsLoggingEnabled(HapiProperties.getCQLEnableDebugLogging());
         context.setDebugMap(debugMap);
     }
 }

--- a/r4/src/main/java/org/opencds/cqf/r4/servlet/CdsHooksServlet.java
+++ b/r4/src/main/java/org/opencds/cqf/r4/servlet/CdsHooksServlet.java
@@ -161,7 +161,7 @@ public class CdsHooksServlet extends HttpServlet {
             Context context = new Context(library);
 
             DebugMap debugMap = new DebugMap();
-            debugMap.setIsLoggingEnabled(true);
+            debugMap.setIsLoggingEnabled(HapiProperties.getCQLDebugLoggingEnabled());
             context.setDebugMap(debugMap);
 
             context.registerDataProvider("http://hl7.org/fhir", provider); // TODO make sure tooling handles remote

--- a/r4/src/main/resources/hapi.properties
+++ b/r4/src/main/resources/hapi.properties
@@ -194,4 +194,4 @@ cds_hooks.prefetch.maxUriLength=
 ##################################################
 # CQL Settings
 ##################################################
-cql.enable_debug_logging=true
+cql.debugLogging.enabled=false

--- a/r4/src/main/resources/hapi.properties
+++ b/r4/src/main/resources/hapi.properties
@@ -190,3 +190,8 @@ cds_hooks.fhirServer.maxCodesPerQuery=
 cds_hooks.fhirServer.expandValueSets=
 cds_hooks.fhirServer.searchStyle=
 cds_hooks.prefetch.maxUriLength=
+
+##################################################
+# CQL Settings
+##################################################
+cql.enable_debug_logging=true

--- a/r4/src/main/resources/logback.xml
+++ b/r4/src/main/resources/logback.xml
@@ -37,4 +37,8 @@
         <!-- <appender-ref ref="htmlAppender" /> -->
     </root>
 
+    <!-- added DebugUtilities logger to facilitate CQL debug logging without turning on debug logging for everything -->
+    <!-- to enable CQL debug logging, set 'cql.debugLogging.enabled=true' in hapi.properties -->
+    <logger name="org.opencds.cqf.cql.engine.debug.DebugUtilities" level="DEBUG" />
+
 </configuration>


### PR DESCRIPTION
contains updates to facilitate turning CQL debug logging on and off via a new 'cql.debugLogging.enabled' property in hapi.properties.

also added a logger config to logback.xml to turn DEBUG logging on for org.opencds.cqf.cql.engine.debug.DebugUtilities, the class that's responsible for writing CQL debug logs (this simplifies configuration by not requiring modifications to both hapi.properties and logback.xml when CQL debug logging is desired, now it only needs to be adjusted in one place).