### PR TITLE
FixesToLibraryContentReflection

### DIFF
--- a/plugin/cql/src/main/java/org/opencds/cqf/ruler/plugin/cql/JpaLibraryContentProvider.java
+++ b/plugin/cql/src/main/java/org/opencds/cqf/ruler/plugin/cql/JpaLibraryContentProvider.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.opencds.cqf.cql.evaluator.cql2elm.content.LibraryContentProvider;
 import org.opencds.cqf.cql.evaluator.cql2elm.content.LibraryContentType;
@@ -47,7 +48,7 @@ public class JpaLibraryContentProvider
 
 		ContentFunctions cf = cachedContentFunctions.computeIfAbsent(libraryDao.getResourceType(), x -> this.getContentFunctions(this.libraryDao.getContext()));
 		try {
-			for (IBaseResource attachment : cf.getAttachments().apply(library)) {
+			for (IBase attachment : cf.getAttachments().apply(library)) {
 				String contentType = cf.getContentType().apply(attachment);
 				if (contentType != null && contentType.equals("text/cql")) {
 					byte[] content = cf.getContent().apply(attachment);

--- a/plugin/cql/src/main/java/org/opencds/cqf/ruler/plugin/cql/LibraryUtilities.java
+++ b/plugin/cql/src/main/java/org/opencds/cqf/ruler/plugin/cql/LibraryUtilities.java
@@ -3,7 +3,7 @@ package org.opencds.cqf.ruler.plugin.cql;
 import java.util.List;
 import java.util.function.Function;
 
-import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IBase;
 import org.opencds.cqf.ruler.plugin.utility.ReflectionUtilities;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -11,36 +11,36 @@ import ca.uhn.fhir.context.FhirContext;
 public interface LibraryUtilities extends ReflectionUtilities {
 
 	public default ContentFunctions getContentFunctions(FhirContext fhirContext) {
-		Function<IBaseResource, List<IBaseResource>> attachments = this
-				.getFunction(fhirContext.getResourceDefinition("Library").getImplementingClass(), "attachment");
-		Function<IBaseResource, String> contentType = this.getPrimitiveFunction(
-				fhirContext.getResourceDefinition("Attachment").getImplementingClass(), "contentType");
-		Function<IBaseResource, byte[]> content = this
-				.getPrimitiveFunction(fhirContext.getResourceDefinition("Attachment").getImplementingClass(), "data");
+		Function<IBase, List<IBase>> attachments = this
+				.getFunction(fhirContext.getResourceDefinition("Library").getImplementingClass(), "content");
+		Function<IBase, String> contentType = this.getPrimitiveFunction(
+				fhirContext.getElementDefinition("Attachment").getImplementingClass(), "contentType");
+		Function<IBase, byte[]> content = this
+				.getPrimitiveFunction(fhirContext.getElementDefinition("Attachment").getImplementingClass(), "data");
 		return new ContentFunctions() {
 
 			@Override
-			public Function<IBaseResource, List<IBaseResource>> getAttachments() {
+			public Function<IBase, List<IBase>> getAttachments() {
 				return attachments;
 			}
 
 			@Override
-			public Function<IBaseResource, String> getContentType() {
+			public Function<IBase, String> getContentType() {
 				return contentType;
 			}
 
 			@Override
-			public Function<IBaseResource, byte[]> getContent() {
+			public Function<IBase, byte[]> getContent() {
 				return content;
 			}
 		};
 	}
 
 	interface ContentFunctions {
-		Function<IBaseResource, List<IBaseResource>> getAttachments();
+		Function<IBase, List<IBase>> getAttachments();
 
-		Function<IBaseResource, String> getContentType();
+		Function<IBase, String> getContentType();
 
-		Function<IBaseResource, byte[]> getContent();
+		Function<IBase, byte[]> getContent();
 	}
 }


### PR DESCRIPTION
Use IBase instead of IBaseResource in order to capture the ElementDefinition of "Attachment" when getting the content of a Library