### PR TITLE
justify filter thresh hold

### DIFF
--- a/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
@@ -40,4 +40,9 @@
         <!-- <appender-ref ref="htmlAppender" /> -->
     </root>
 
+    <logger name = "org.opencds.cqf.cql.engine.debug" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE"/>
+    </logger>
+
 </configuration>

--- a/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
@@ -34,7 +34,7 @@
         </encoder>
     </appender>
   
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
@@ -1,12 +1,11 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!--
-          The following filter deny all events with a level below INFO, that is TRACE and DEBUG
+        <!-- The following filter deny all events with a level below INFO, that is TRACE and DEBUG -->
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
-        -->
+
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>
@@ -34,7 +33,7 @@
         </encoder>
     </appender>
   
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-dstu3/src/main/webapp/WEB-INF/classes/logback.xml
@@ -1,9 +1,12 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!--
+          The following filter deny all events with a level below INFO, that is TRACE and DEBUG
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
+        -->
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>

--- a/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
@@ -39,4 +39,9 @@
         <!-- <appender-ref ref="htmlAppender" /> -->
     </root>
 
+    <logger name = "org.opencds.cqf.cql.engine.debug" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE"/>
+    </logger>
+
 </configuration>

--- a/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
@@ -1,11 +1,10 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!--
-        The following filter deny all events with a level below INFO, that is TRACE and DEBUG
+        <!-- The following filter deny all events with a level below INFO, that is TRACE and DEBUG -->
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
-        </filter>  -->
+        </filter>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>
@@ -33,7 +32,7 @@
         </encoder>
     </appender>
   
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
@@ -33,7 +33,7 @@
         </encoder>
     </appender>
   
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/cqf-ruler-r4/src/main/webapp/WEB-INF/classes/logback.xml
@@ -1,9 +1,11 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!--
+        The following filter deny all events with a level below INFO, that is TRACE and DEBUG
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
-        </filter>
+        </filter>  -->
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>

--- a/dstu3/src/main/resources/logback.xml
+++ b/dstu3/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
         </encoder>
     </appender>
   
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/dstu3/src/main/resources/logback.xml
+++ b/dstu3/src/main/resources/logback.xml
@@ -1,9 +1,10 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-<!--        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">-->
-<!--            <level>INFO</level>-->
-<!--        </filter>-->
+        <!-- The following filter deny all events with a level below INFO, that is TRACE and DEBUG -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>
@@ -31,7 +32,7 @@
         </encoder>
     </appender>
   
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/dstu3/src/main/resources/logback.xml
+++ b/dstu3/src/main/resources/logback.xml
@@ -1,9 +1,9 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
+<!--        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">-->
+<!--            <level>INFO</level>-->
+<!--        </filter>-->
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>

--- a/r4/src/main/resources/logback.xml
+++ b/r4/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
         </encoder>
     </appender>
   
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/r4/src/main/resources/logback.xml
+++ b/r4/src/main/resources/logback.xml
@@ -1,9 +1,10 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-<!--        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">-->
-<!--            <level>INFO</level>-->
-<!--        </filter>-->
+        <!-- The following filter deny all events with a level below INFO, that is TRACE and DEBUG -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>
@@ -31,7 +32,7 @@
         </encoder>
     </appender>
   
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
         <!-- <appender-ref ref="htmlAppender" /> -->

--- a/r4/src/main/resources/logback.xml
+++ b/r4/src/main/resources/logback.xml
@@ -1,9 +1,9 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
+<!--        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">-->
+<!--            <level>INFO</level>-->
+<!--        </filter>-->
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
https://logback.qos.ch/manual/filters.html
The following deny all events with a level below INFO, that is TRACE and DEBUG 
    `<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
      <level>INFO</level>
    </filter>`

The log levels:
.........................
/** No events will be logged.
 */
OFF(0),

/**
 * A severe error that will prevent the application from continuing.
 */
FATAL(100),

/**
 * An error in the application, possibly recoverable.
 */
ERROR(200),

/**
 * An event that might possible lead to an error.
 */
WARN(300),

/**
 * An event for informational purposes.
 */
INFO(400),

/**
 * A general debugging event.
 */
DEBUG(500),

/**
 * A fine-grained debug message, typically capturing the flow through the application.
 */
TRACE(600),

/**
 * All events should be logged.
 */
ALL(Integer.MAX_VALUE);

