### PR TITLE
Resolve #460 - Don't register r4 providers in dstu3 mode

### DIFF
--- a/plugin/case-reporting/src/main/java/org/opencds/cqf/ruler/casereporting/CaseReportingConfig.java
+++ b/plugin/case-reporting/src/main/java/org/opencds/cqf/ruler/casereporting/CaseReportingConfig.java
@@ -2,6 +2,7 @@ package org.opencds.cqf.ruler.casereporting;
 
 import org.opencds.cqf.ruler.api.OperationProvider;
 import org.opencds.cqf.ruler.casereporting.r4.MeasureDataProcessProvider;
+import org.opencds.cqf.ruler.casereporting.r4.ProcessMessageProvider;
 import org.opencds.cqf.ruler.external.annotations.OnR4Condition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -9,7 +10,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnProperty(prefix = "hapi.fhir.casereporting", name ="enabled", havingValue = "true", matchIfMissing=true)
+@ConditionalOnProperty(prefix = "hapi.fhir.casereporting", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class CaseReportingConfig {
 	@Bean
 	public CaseReportingProperties caseReportingProperties() {
@@ -20,6 +21,12 @@ public class CaseReportingConfig {
 	@Conditional(OnR4Condition.class)
 	public OperationProvider r4MeasureDataProcessor() {
 		return new MeasureDataProcessProvider();
+	}
+
+	@Bean
+	@Conditional(OnR4Condition.class)
+	public ProcessMessageProvider r4ProcessMessageProvider() {
+		return new ProcessMessageProvider();
 	}
 
 }

--- a/plugin/case-reporting/src/main/java/org/opencds/cqf/ruler/casereporting/r4/ProcessMessageProvider.java
+++ b/plugin/case-reporting/src/main/java/org/opencds/cqf/ruler/casereporting/r4/ProcessMessageProvider.java
@@ -25,7 +25,6 @@ import org.hl7.fhir.r4.model.UriType;
 import org.opencds.cqf.ruler.provider.DaoRegistryOperationProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.model.api.annotation.Description;
@@ -36,7 +35,6 @@ import ca.uhn.fhir.rest.api.IVersionSpecificBundleFactory;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.util.BundleUtil;
 
-@Component
 public class ProcessMessageProvider extends DaoRegistryOperationProvider {
 	private static final Logger logger = LoggerFactory.getLogger(ProcessMessageProvider.class);
 


### PR DESCRIPTION
* Remove the `Component` annotation from the r4 process message provider
* Add that provider to the config
* closes #460 