### PR TITLE
Update Docker image to Java 18 for container-aware improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,8 +14,8 @@
 				"-XX:TieredStopAtLevel=1",
 				"-Xverify:none",
 				"-Dspring.main.lazy-initialization=true",
-				"-Dloader.debug=true",
-				"-Ddebug=true"
+				"-Ddebug=true",
+				"-Dloader.debug=true"
 			],
 			"stepFilters": {
 				"classNameFilters": [
@@ -59,8 +59,8 @@
 				"-XX:TieredStopAtLevel=1",
 				"-Xverify:none",
 				"-Dspring.main.lazy-initialization=true",
-				"-Dloader.debug=true",
 				"-Ddebug=true",
+				"-Dloader.debug=true",
 				"-Dhapi.fhir.fhir_version=DSTU3"
 			],
 			"stepFilters": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:11
+FROM openjdk:18-slim-bullseye
 
-RUN apt update && apt upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir server
 RUN mkdir plugin


### PR DESCRIPTION
* JDK 17+ contains improvements that allows the JVM to be container aware improving performance in some deployments