### PR TITLE
#481: First pass at fixing CDS Hooks service discovery caching issue 

### DIFF
--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksConfig.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksConfig.java
@@ -1,9 +1,6 @@
 package org.opencds.cqf.ruler.cdshooks;
 
-import java.util.concurrent.atomic.AtomicReference;
-
-import com.google.gson.JsonArray;
-
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import org.opencds.cqf.ruler.cdshooks.providers.ProviderConfiguration;
 import org.opencds.cqf.ruler.cql.CqlProperties;
 import org.opencds.cqf.ruler.external.annotations.OnDSTU3Condition;
@@ -33,9 +30,9 @@ public class CdsHooksConfig {
 		return new ProviderConfiguration(cdsProperties, cqlProperties);
 	}
 
-	@Bean(name = "globalCdsServiceCache")
-	public AtomicReference<JsonArray> cdsServiceCache() {
-		return new AtomicReference<>();
+	@Bean
+	public CdsServiceInterceptor cdsServiceInterceptor(DaoRegistry daoRegistry) {
+		return new CdsServiceInterceptor(daoRegistry);
 	}
 
 	@Bean

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsServiceInterceptor.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsServiceInterceptor.java
@@ -1,0 +1,74 @@
+package org.opencds.cqf.ruler.cdshooks;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.PlanDefinition;
+import org.opencds.cqf.ruler.cdshooks.discovery.DiscoveryResolutionR4;
+import org.opencds.cqf.ruler.cdshooks.discovery.DiscoveryResolutionStu3;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+@Interceptor
+public class CdsServiceInterceptor implements org.opencds.cqf.ruler.api.Interceptor {
+	private static final Logger logger = LoggerFactory.getLogger(CdsServiceInterceptor.class);
+
+	private AtomicReference<JsonArray> cdsServiceCache;
+	private DiscoveryResolutionR4 discoveryResolutionR4;
+	private DiscoveryResolutionStu3 discoveryResolutionStu3;
+
+	public CdsServiceInterceptor(DaoRegistry daoRegistry) {
+		this.discoveryResolutionR4 = new DiscoveryResolutionR4(daoRegistry);
+		this.discoveryResolutionStu3 = new DiscoveryResolutionStu3(daoRegistry);
+		this.cdsServiceCache = new AtomicReference<>(new JsonArray());
+	}
+
+	public AtomicReference<JsonArray> getCdsServiceCache() {
+		return this.cdsServiceCache;
+	}
+
+	@Hook(Pointcut.STORAGE_PRECOMMIT_RESOURCE_CREATED)
+	public void insert(IBaseResource resource) {
+		try {
+			if (resource instanceof PlanDefinition) {
+				cdsServiceCache.get().add(discoveryResolutionR4.resolveService((PlanDefinition) resource));
+			} else if (resource instanceof org.hl7.fhir.dstu3.model.PlanDefinition) {
+				cdsServiceCache.get().add(discoveryResolutionStu3.resolveService((org.hl7.fhir.dstu3.model.PlanDefinition) resource));
+			}
+		} catch (Exception e) {
+			logger.info(String.format("Failed to create service for %s", resource.getIdElement().getIdPart()));
+		}
+	}
+
+	@Hook(Pointcut.STORAGE_PRECOMMIT_RESOURCE_UPDATED)
+	public void update(IBaseResource oldResource, IBaseResource newResource) {
+		try {
+			if (newResource instanceof PlanDefinition || newResource instanceof org.hl7.fhir.dstu3.model.PlanDefinition) {
+				delete(oldResource);
+				insert(newResource);
+			}
+		} catch (Exception e) {
+			logger.info(String.format("Failed to update service for %s", newResource.getIdElement().getIdPart()));
+		}
+	}
+
+	@Hook(Pointcut.STORAGE_PRECOMMIT_RESOURCE_DELETED)
+	public void delete(IBaseResource resource) {
+		try {
+			for (int i = 0; i<cdsServiceCache.get().size(); i++) {
+				if (((JsonObject) cdsServiceCache.get().get(i)).get("id").getAsString().equals(resource.getIdElement().getIdPart())) {
+					cdsServiceCache.get().remove(i);
+					break;
+				}
+			}
+		} catch (Exception e) {
+			logger.info(String.format("Failed to delete service for %s", resource.getIdElement().getIdPart()));
+		}
+	}
+}

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/discovery/DiscoveryResolutionR4.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/discovery/DiscoveryResolutionR4.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.ruler.cdshooks.discovery;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gson.JsonObject;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.DataRequirement;
@@ -196,6 +197,10 @@ public class DiscoveryResolutionR4 implements DaoRegistryUser {
 		}
 
 		return response;
+	}
+
+	public JsonObject resolveService(PlanDefinition planDefinition) {
+		return new DiscoveryElementR4(planDefinition, getPrefetchUrlList(planDefinition)).getAsJson();
 	}
 
 	private String mapCodePathToSearchParam(String dataType, String path) {

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/discovery/DiscoveryResolutionStu3.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/discovery/DiscoveryResolutionStu3.java
@@ -3,6 +3,7 @@ package org.opencds.cqf.ruler.cdshooks.discovery;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gson.JsonObject;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.DataRequirement;
@@ -205,6 +206,10 @@ public class DiscoveryResolutionStu3 implements DaoRegistryUser  {
 		}
 
 		return response;
+	}
+
+	public JsonObject resolveService(PlanDefinition planDefinition) {
+		return new DiscoveryElementStu3(planDefinition, getPrefetchUrlList(planDefinition)).getAsJson();
 	}
 
 	private String mapCodePathToSearchParam(String dataType, String path) {

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/dstu3/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/dstu3/CdsHooksServlet.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -27,7 +26,7 @@ import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.ruler.behavior.DaoRegistryUser;
-import org.opencds.cqf.ruler.cdshooks.discovery.DiscoveryResolutionStu3;
+import org.opencds.cqf.ruler.cdshooks.CdsServiceInterceptor;
 import org.opencds.cqf.ruler.cdshooks.evaluation.EvaluationContext;
 import org.opencds.cqf.ruler.cdshooks.evaluation.Stu3EvaluationContext;
 import org.opencds.cqf.ruler.cdshooks.hooks.Hook;
@@ -98,7 +97,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 	private ModelResolver modelResolver;
 
 	@Autowired
-	private AtomicReference<JsonArray> services;
+	CdsServiceInterceptor cdsServiceInterceptor;
 
 	protected ProviderConfiguration getProviderConfiguration() {
 		return this.providerConfiguration;
@@ -317,21 +316,13 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 	}
 
 	private JsonArray getServicesArray() {
-		JsonArray cachedServices = this.services.get();
-		if (cachedServices == null || cachedServices.size() == 0) {
-			cachedServices = getServices().get("services").getAsJsonArray();
-			services.set(cachedServices);
-		}
-
-		return cachedServices;
+		return this.cdsServiceInterceptor.getCdsServiceCache().get();
 	}
 
 	private JsonObject getServices() {
-		DiscoveryResolutionStu3 discoveryResolutionStu3 = new DiscoveryResolutionStu3(daoRegistry);
-
-		discoveryResolutionStu3.setMaxUriLength(this.getProviderConfiguration().getMaxUriLength());
-
-		return discoveryResolutionStu3.resolve().getAsJson();
+		JsonObject services = new JsonObject();
+		services.add("services", this.cdsServiceInterceptor.getCdsServiceCache().get());
+		return services;
 	}
 
 	private String toJsonResponse(List<CdsCard> cards) {

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -27,7 +26,7 @@ import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 import org.opencds.cqf.ruler.behavior.DaoRegistryUser;
-import org.opencds.cqf.ruler.cdshooks.discovery.DiscoveryResolutionR4;
+import org.opencds.cqf.ruler.cdshooks.CdsServiceInterceptor;
 import org.opencds.cqf.ruler.cdshooks.evaluation.EvaluationContext;
 import org.opencds.cqf.ruler.cdshooks.evaluation.R4EvaluationContext;
 import org.opencds.cqf.ruler.cdshooks.hooks.Hook;
@@ -81,6 +80,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 
 	@Autowired
 	private LibraryLoaderFactory libraryLoaderFactory;
+
 	@Autowired
 	private JpaLibraryContentProviderFactory jpaLibraryContentProviderFactory;
 
@@ -97,7 +97,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 	private ModelResolver modelResolver;
 
 	@Autowired
-	private AtomicReference<JsonArray> services;
+	CdsServiceInterceptor cdsServiceInterceptor;
 
 	protected ProviderConfiguration getProviderConfiguration() {
 		return this.providerConfiguration;
@@ -119,6 +119,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 			throws ServletException, IOException {
 
 		logger.info(request.getRequestURI());
+
 		if (!request.getRequestURL().toString().endsWith("/cds-services")
 				&& !request.getRequestURL().toString().endsWith("/cds-services/")) {
 			logger.error(request.getRequestURI());
@@ -132,8 +133,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 
 	@Override
 	@SuppressWarnings("deprecation")
-	protected void doPost(HttpServletRequest request, HttpServletResponse response)
-			throws ServletException, IOException {
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		logger.info(request.getRequestURI());
 
 		try {
@@ -317,21 +317,13 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 	}
 
 	private JsonArray getServicesArray() {
-		JsonArray cachedServices = this.services.get();
-		if (cachedServices == null || cachedServices.size() == 0) {
-			cachedServices = getServices().get("services").getAsJsonArray();
-			services.set(cachedServices);
-		}
-
-		return cachedServices;
+		return this.cdsServiceInterceptor.getCdsServiceCache().get();
 	}
 
 	private JsonObject getServices() {
-		DiscoveryResolutionR4 discoveryResolutionR4 = new DiscoveryResolutionR4(daoRegistry);
-
-		discoveryResolutionR4.setMaxUriLength(this.getProviderConfiguration().getMaxUriLength());
-
-		return discoveryResolutionR4.resolve().getAsJson();
+		JsonObject services = new JsonObject();
+		services.add("services", this.cdsServiceInterceptor.getCdsServiceCache().get());
+		return services;
 	}
 
 	private String toJsonResponse(List<CdsCard> cards) {

--- a/plugin/cds-hooks/src/test/resources/HelloWorld-plandefinition.json
+++ b/plugin/cds-hooks/src/test/resources/HelloWorld-plandefinition.json
@@ -1,0 +1,74 @@
+{
+	"resourceType": "PlanDefinition",
+	"id": "hello-world-patient-view",
+	"url": "http://fhir.org/guides/cdc/opioid-cds/PlanDefinition/hello-world-patient-view",
+	"identifier": [ {
+		"use": "official",
+		"value": "helloworld-patient-view-sample"
+	} ],
+	"version": "1.0.0",
+	"name": "HelloWorldPatientView",
+	"title": "Hello World (patient-view)",
+	"type": {
+		"coding": [ {
+			"system": "http://hl7.org/fhir/plan-definition-type",
+			"code": "eca-rule",
+			"display": "ECA Rule"
+		} ]
+	},
+	"status": "draft",
+	"date": "2021-05-26T00:00:00-08:00",
+	"publisher": "Alphora",
+	"description": "This PlanDefinition defines a simple Hello World recommendation that triggers on patient-view.",
+	"purpose": "The purpose of this is to test the system to make sure we have complete end-to-end functionality",
+	"usage": "This is to be used in conjunction with a patient-facing FHIR application.",
+	"useContext": [ {
+		"code": {
+			"system": "http://hl7.org/fhir/usage-context-type",
+			"version": "4.0.1",
+			"code": "focus",
+			"display": "Clinical Focus"
+		}
+	} ],
+	"jurisdiction": [ {
+		"coding": [ {
+			"system": "http://hl7.org/fhir/ValueSet/iso3166-1-3",
+			"version": "4.0.1",
+			"code": "USA",
+			"display": "United States of America"
+		} ]
+	} ],
+	"library": [ {
+		"reference": "http://fhir.org/guides/cdc/opioid-cds/Library/HelloWorldPatientView"
+	} ],
+	"action": [ {
+		"label": "Hello World!",
+		"title": "Hello  World!",
+		"description": "A simple Hello World (patient-view) recommendation",
+		"triggerDefinition": [ {
+			"type": "named-event",
+			"eventName": "patient-view"
+		} ],
+		"condition": [ {
+			"kind": "start",
+			"description": "Whether or not a Hello World! card should be returned",
+			"language": "text/cql",
+			"expression": "Main Action Condition Expression Is True"
+		} ],
+		"type": {
+			"system": "http://terminology.hl7.org/CodeSystem/action-type",
+			"code": "create",
+			"display": "Create"
+		},
+		"dynamicValue": [ {
+			"path": "action.title",
+			"expression": "Get Title"
+		}, {
+			"path": "action.description",
+			"expression": "Get Description"
+		}, {
+			"path": "activity.extension",
+			"expression": "Get Indicator"
+		} ]
+	} ]
+}

--- a/plugin/cds-hooks/src/test/resources/Screening-plandefinition.json
+++ b/plugin/cds-hooks/src/test/resources/Screening-plandefinition.json
@@ -1,0 +1,404 @@
+{
+	"resourceType": "PlanDefinition",
+	"id": "plandefinition-Screening",
+	"url": "http://fhir.org/guides/nachc/hiv-cds/PlanDefinition/plandefinition-Screening",
+	"identifier": [ {
+		"use": "official",
+		"value": "nachc-Screening"
+	} ],
+	"version": "1.0.0",
+	"name": "Screening",
+	"title": "CDC HIV Screening",
+	"type": {
+		"coding": [ {
+			"system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+			"code": "eca-rule",
+			"display": "ECA Rule"
+		} ]
+	},
+	"status": "draft",
+	"date": "2021-07-31T00:00:00-08:00",
+	"publisher": "National Association of Community Health Centers, Inc. (NACHC)",
+	"description": "This PlanDefinition defines a a Clinical Decision Support CDC Recommendation for HIV Screening",
+	"useContext": [ {
+		"code": {
+			"system": "http://terminology.hl7.org/CodeSystem/usage-context-type",
+			"version": "4.0.1",
+			"code": "focus",
+			"display": "Clinical Focus"
+		},
+		"valueCodeableConcept": {
+			"coding": [ {
+				"system": "http://hl7.org/fhir/sid/icd-10-cm",
+				"version": "2021",
+				"code": "B20",
+				"display": "Human immunodeficiency virus [HIV] disease"
+			} ]
+		}
+	} ],
+	"jurisdiction": [ {
+		"coding": [ {
+			"system": "http://hl7.org/fhir/ValueSet/iso3166-1-3",
+			"version": "4.0.1",
+			"code": "USA",
+			"display": "United States of America"
+		} ]
+	} ],
+	"purpose": "The purpose of this is to identify and build CDS support for HIV Screening.",
+	"usage": "This is to be used in conjunction with a patient-facing FHIR application.",
+	"copyright": "© Copyright National Association of Community Health Centers, Inc. (NACHC) 2021+.",
+	"topic": [ {
+		"coding": [ {
+			"system": "http://terminology.hl7.org/CodeSystem/definition-topic",
+			"version": "4.0.1",
+			"code": "assessment",
+			"display": "Assessment"
+		} ],
+		"text": "HIV Management"
+	} ],
+	"library": [ "http://fhir.org/guides/nachc/hiv-cds/Library/Screening" ],
+	"action": [ {
+		"title": "HIV Screening",
+		"documentation": [ {
+			"type": "documentation",
+			"display": "Info for those with HIV",
+			"url": "https://www.cdc.gov/hiv/guidelines/testing.html"
+		} ],
+		"trigger": [ {
+			"type": "named-event",
+			"name": "patient-view"
+		} ],
+		"condition": [ {
+			"kind": "start",
+			"expression": {
+				"language": "text/cql",
+				"expression": "'true'"
+			}
+		} ],
+		"dynamicValue": [ {
+			"path": "action.description",
+			"expression": {
+				"description": "Patient Name.",
+				"language": "text/cql.identifier",
+				"expression": "Patient Name"
+			}
+		}, {
+			"path": "action.extension",
+			"expression": {
+				"language": "text/cql.identifier",
+				"expression": "Info"
+			}
+		} ],
+		"action": [ {
+			"prefix": "Recommend HIV Screening Test.",
+			"title": "Never Tested Recommendation",
+			"description": "Perform CDC Recommendation for Never Tested Treatment if conditions are met.",
+			"condition": [ {
+				"kind": "applicability",
+				"expression": {
+					"description": "Determine if Patient is in msm population.",
+					"language": "text/cql.identifier",
+					"expression": "Never Tested Condition"
+				}
+			} ],
+			"type": {
+				"coding": [ {
+					"system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+					"code": "create",
+					"display": "Create"
+				} ]
+			},
+			"selectionBehavior": "any",
+			"definitionCanonical": "http://fhir.org/guides/nachc/hiv-cds/ActivityDefinition/activitydefinition-hiv-screening-request",
+			"dynamicValue": [ {
+				"path": "action.title",
+				"expression": {
+					"description": "Provides Recommendation for Never Tested screenings.",
+					"language": "text/cql.identifier",
+					"expression": "Never Tested Recommendation"
+				}
+			}, {
+				"path": "action.description",
+				"expression": {
+					"description": "Provides Rationale for Never Tested screenings.",
+					"language": "text/cql.identifier",
+					"expression": "Never Tested Rationale"
+				}
+			}, {
+				"path": "action.extension",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Never Tested Indicator"
+				}
+			}, {
+				"path": "asNeededBoolean",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Never Tested Condition"
+				}
+			} ],
+			"action": [ {
+				"description": "Will perform HIV screening"
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 1 month."
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 12 months."
+			}, {
+				"description": "Will not perform HIV screening at this time - patient declined."
+			} ]
+		}, {
+			"prefix": "Recommend HIV Screening Test.",
+			"title": "MSM Recommendation",
+			"description": "Perform CDC Recommendation for MSM if conditions are met for either 3 month or annual testing.",
+			"condition": [ {
+				"kind": "applicability",
+				"expression": {
+					"description": "Determine if Patient is in msm population.",
+					"language": "text/cql.identifier",
+					"expression": "MSM Condition"
+				}
+			} ],
+			"type": {
+				"coding": [ {
+					"system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+					"code": "create",
+					"display": "Create"
+				} ]
+			},
+			"selectionBehavior": "any",
+			"definitionCanonical": "http://fhir.org/guides/nachc/hiv-cds/ActivityDefinition/activitydefinition-hiv-screening-request",
+			"dynamicValue": [ {
+				"path": "action.title",
+				"expression": {
+					"description": "Provides Recommendation for screening.",
+					"language": "text/cql.identifier",
+					"expression": "MSM Recommendation"
+				}
+			}, {
+				"path": "action.description",
+				"expression": {
+					"description": "Provides Rationale for screening.",
+					"language": "text/cql.identifier",
+					"expression": "MSM Rationale"
+				}
+			}, {
+				"path": "action.extension",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "MSM Indicator"
+				}
+			}, {
+				"path": "asNeededBoolean",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "MSM Condition"
+				}
+			} ],
+			"action": [ {
+				"description": "Will perform HIV screening"
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 1 month."
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 12 months."
+			}, {
+				"description": "Will not perform HIV screening at this time - patient declined."
+			} ]
+		}, {
+			"prefix": "Recommend HIV Screening Test.",
+			"title": "Pregnancy Recommendation",
+			"description": "Perform CDC Recommendation for Pregnancy if conditions are met for first prenatal visit or third trimester high risk testing.",
+			"condition": [ {
+				"kind": "applicability",
+				"expression": {
+					"description": "Determine if Patient is in msm population.",
+					"language": "text/cql.identifier",
+					"expression": "Pregnant Condition"
+				}
+			} ],
+			"type": {
+				"coding": [ {
+					"system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+					"code": "create",
+					"display": "Create"
+				} ]
+			},
+			"selectionBehavior": "any",
+			"definitionCanonical": "http://fhir.org/guides/nachc/hiv-cds/ActivityDefinition/activitydefinition-hiv-screening-request",
+			"dynamicValue": [ {
+				"path": "action.title",
+				"expression": {
+					"description": "Provides Recommendation for Pregnancy screenings.",
+					"language": "text/cql.identifier",
+					"expression": "Pregnant Recommendation"
+				}
+			}, {
+				"path": "action.description",
+				"expression": {
+					"description": "Provides Rationale for Pregnancy screenings.",
+					"language": "text/cql.identifier",
+					"expression": "Pregnant Rationale"
+				}
+			}, {
+				"path": "action.extension",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Pregnant Indicator"
+				}
+			}, {
+				"path": "asNeededBoolean",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Pregnant Condition"
+				}
+			} ],
+			"action": [ {
+				"description": "Will perform HIV screening"
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 1 month."
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 12 months."
+			}, {
+				"description": "Will not perform HIV screening at this time - patient declined."
+			} ]
+		}, {
+			"prefix": "Recommend HIV Screening Test.",
+			"title": "Seeking Treatment Recommendation",
+			"description": "Perform CDC Recommendation for Seeking STD Treatment if conditions are met.",
+			"condition": [ {
+				"kind": "applicability",
+				"expression": {
+					"description": "Determine if Patient is in msm population.",
+					"language": "text/cql.identifier",
+					"expression": "Seeking STD Treatment Condition"
+				}
+			} ],
+			"type": {
+				"coding": [ {
+					"system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+					"code": "create",
+					"display": "Create"
+				} ]
+			},
+			"selectionBehavior": "any",
+			"definitionCanonical": "http://fhir.org/guides/nachc/hiv-cds/ActivityDefinition/activitydefinition-hiv-screening-request",
+			"dynamicValue": [ {
+				"path": "action.title",
+				"expression": {
+					"description": "Provides Recommendation for Seeking STD Treatment screenings.",
+					"language": "text/cql.identifier",
+					"expression": "Seeking STD Treatment Recommendation"
+				}
+			}, {
+				"path": "action.description",
+				"expression": {
+					"description": "Provides Rationale for Seeking STD Treatment screenings.",
+					"language": "text/cql.identifier",
+					"expression": "Seeking STD Treatment Rationale"
+				}
+			}, {
+				"path": "action.extension",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Seeking STD Treatment Indicator"
+				}
+			}, {
+				"path": "asNeededBoolean",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Seeking STD Treatment Condition"
+				}
+			} ],
+			"action": [ {
+				"description": "Will perform HIV screening"
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 1 month."
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 12 months."
+			}, {
+				"description": "Will not perform HIV screening at this time - patient declined."
+			} ]
+		}, {
+			"prefix": "Recommend HIV Screening Test.",
+			"title": "Risk Level Recommendation",
+			"description": "Determines type of recommendation based on risk level regarding status of HIV Screening.",
+			"condition": [ {
+				"kind": "applicability",
+				"expression": {
+					"description": "Determine if Patient is in screening population.",
+					"language": "text/cql.identifier",
+					"expression": "Risk Level Condition"
+				}
+			} ],
+			"type": {
+				"coding": [ {
+					"system": "http://terminology.hl7.org/CodeSystem/plan-definition-type",
+					"code": "create",
+					"display": "Create"
+				} ]
+			},
+			"selectionBehavior": "any",
+			"definitionCanonical": "http://fhir.org/guides/nachc/hiv-cds/ActivityDefinition/activitydefinition-hiv-screening-request",
+			"dynamicValue": [ {
+				"path": "action.title",
+				"expression": {
+					"description": "Determines what recommendation patient should be provided.",
+					"language": "text/cql.identifier",
+					"expression": "Risk Level Recommendation"
+				}
+			}, {
+				"path": "action.description",
+				"expression": {
+					"description": "Rationale for recommendation type.",
+					"language": "text/cql.identifier",
+					"expression": "Risk Level Rationale"
+				}
+			}, {
+				"path": "action.extension",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Risk Level Indicator Status"
+				}
+			}, {
+				"path": "asNeededBoolean",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Risk Level Condition"
+				}
+			} ],
+			"action": [ {
+				"description": "Will perform HIV screening"
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 1 month."
+			}, {
+				"description": "Will not perform HIV screening at this time - Snooze 12 months."
+			}, {
+				"description": "Will not perform HIV screening at this time - patient declined."
+			} ]
+		}, {
+			"title": "Exclusion from HIV Screening",
+			"description": "Determines if patient was excluded from HIV Screening Recommendation.",
+			"condition": [ {
+				"kind": "applicability",
+				"expression": {
+					"description": "Determine if Patient is in hiv exclusion population.",
+					"language": "text/cql.identifier",
+					"expression": "Meets Exclusion Criteria"
+				}
+			} ],
+			"dynamicValue": [ {
+				"path": "action.description",
+				"expression": {
+					"description": "Rationale for why patient was excluded from the hiv screening.",
+					"language": "text/cql.identifier",
+					"expression": "Exclusion Reason"
+				}
+			}, {
+				"path": "action.extension",
+				"expression": {
+					"language": "text/cql.identifier",
+					"expression": "Info"
+				}
+			} ]
+		} ]
+	} ]
+}


### PR DESCRIPTION
Was not able to get the resource listener to behave as expected. I instead implemented an interceptor that updates a cache as PlanDefinitions are created/updated/deleted. I realize this is not the solution that was advised in the issue. If this solution is not acceptable, I can go back to the drawing board.

There is a test to validate the cache behavior. However, local testing will need to be done by the reviewer to verify that the services are being updated properly during discovery. I have done my own local testing and everything looks good. Just an FYI.