### PR TITLE
CDS Hooks service remote data configuration

### DIFF
--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksProperties.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksProperties.java
@@ -80,4 +80,14 @@ public class CdsHooksProperties {
 			this.maxUriLength = maxUriLength;
 		}
 	}
+
+	private boolean useRemoteData;
+
+	public boolean isUseRemoteData() {
+		return useRemoteData;
+	}
+
+	public void setUseRemoteData(boolean useRemoteData) {
+		this.useRemoteData = useRemoteData;
+	}
 }

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/evaluation/EvaluationContext.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/evaluation/EvaluationContext.java
@@ -1,6 +1,7 @@
 package org.opencds.cqf.ruler.cdshooks.evaluation;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.opencds.cqf.cql.engine.fhir.retrieve.Dstu3FhirQueryGenerator;
@@ -129,7 +130,9 @@ public abstract class EvaluationContext<T extends IBaseResource> {
             }
             // TODO: Get the "system" terminology provider.
             prefetchRetriever.setTerminologyProvider(context.resolveTerminologyProvider());
-            PriorityRetrieveProvider priorityRetrieveProvider = new PriorityRetrieveProvider(Arrays.asList(prefetchRetriever, remoteRetriever));
+            PriorityRetrieveProvider priorityRetrieveProvider = providerConfiguration.getUseRemoteData()
+                    ? new PriorityRetrieveProvider(Arrays.asList(prefetchRetriever, remoteRetriever))
+                    : new PriorityRetrieveProvider(Collections.singletonList(prefetchRetriever));
             remoteProvider = new CompositeDataProvider(modelResolver, priorityRetrieveProvider);
         }
         return remoteProvider;

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
@@ -8,21 +8,23 @@ import ca.uhn.fhir.rest.api.SearchStyleEnum;
 public class ProviderConfiguration {
 
 	public static final ProviderConfiguration DEFAULT_PROVIDER_CONFIGURATION = new ProviderConfiguration(true, 64,
-			SearchStyleEnum.GET, 8000, false);
+			SearchStyleEnum.GET, 8000, false, true);
 
 	private int maxCodesPerQuery;
 	private SearchStyleEnum searchStyle;
 	private boolean expandValueSets;
 	private int maxUriLength;
 	private boolean cqlLoggingEnabled;
+	private boolean useRemoteData;
 
 	public ProviderConfiguration(boolean expandValueSets, int maxCodesPerQuery, SearchStyleEnum searchStyle,
-			int maxUriLength, boolean cqlLoggingEnabled) {
+			int maxUriLength, boolean cqlLoggingEnabled, boolean useRemoteData) {
 		this.maxCodesPerQuery = maxCodesPerQuery;
 		this.searchStyle = searchStyle;
 		this.expandValueSets = expandValueSets;
 		this.maxUriLength = maxUriLength;
 		this.cqlLoggingEnabled = cqlLoggingEnabled;
+		this.useRemoteData = useRemoteData;
 	}
 
 	public ProviderConfiguration(CdsHooksProperties cdsProperties, CqlProperties cqlProperties) {
@@ -31,6 +33,7 @@ public class ProviderConfiguration {
 		this.searchStyle = cdsProperties.getFhirServer().getSearchStyle();
 		this.maxUriLength = cdsProperties.getPrefetch().getMaxUriLength();
 		this.cqlLoggingEnabled = cqlProperties.getOptions().getCqlEngineOptions().isDebugLoggingEnabled();
+		this.useRemoteData = cdsProperties.isUseRemoteData();
 	}
 
 	public int getMaxCodesPerQuery() {
@@ -51,5 +54,13 @@ public class ProviderConfiguration {
 
 	public boolean getCqlLoggingEnabled() {
 		return this.cqlLoggingEnabled;
+	}
+
+	public boolean getUseRemoteData() {
+		return this.useRemoteData;
+	}
+
+	public void setUseRemoteData(boolean useRemoteData) {
+		this.useRemoteData = useRemoteData;
 	}
 }

--- a/plugin/cds-hooks/src/main/resources/application.yaml
+++ b/plugin/cds-hooks/src/main/resources/application.yaml
@@ -8,4 +8,5 @@ hapi:
             searchStyle: GET
          prefetch:
             maxUriLength: 8000
+         useRemoteData: true
 

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -224,6 +224,7 @@ hapi:
             searchStyle: GET
          prefetch:
             maxUriLength: 8000
+         useRemoteData: true
 #elasticsearch:
 #  debug:
 #    pretty_print_json_log: false


### PR DESCRIPTION
We are currently in a tricky situation with our current all-or-nothing prefetch resolution policy. We have implementers that require both prefetch and remote data retrieval (opioid participants) and implementers that want only prefetch resolution. 

I am not sure that this is an ideal solution and am open to suggestions for an improved implementation of this behavior.

I have also received requests that , once partial prefetch resolution is implemented, there exists a configuration option to enable/disable that. This PR is attempting to setup for that and resolve an ongoing issue.