### PR TITLE
disabled html coding for return cards in cdshooks

### DIFF
--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
@@ -176,8 +176,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 			Cards result = new Cards();
 			result.cards = cards;
 			// Using GSON pretty print format as Jackson's is ugly
-			String jsonResponse = new GsonBuilder().setPrettyPrinting().create().toJson(
-					JsonParser.parseString(mapper.writeValueAsString(result)));
+			String jsonResponse = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create().toJson(JsonParser.parseString(mapper.writeValueAsString(result)));
 			logger.info(jsonResponse);
 			response.getWriter().println(jsonResponse);
 		} catch (BaseServerResponseException e) {


### PR DESCRIPTION
Return cards were encoding such things as < br / >, not allowing cards to display as markdown. Disabled HTML Escaping in call to GsonBuilder.