### PR TITLE
add nexus staging plugin back to enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -925,6 +925,10 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
 					</plugin>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
On top of the nexus bug that was found yesterday, which prevented publishing snapshot artifacts to maven repository, we moved nexus to base profile and removed from release. This for some reason blocked GPG signature on artifacts on release profile. I added this back to release profile and was able to successfully upload and sign artifacts.