### PR TITLE
Force newer version of commons-text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
 			</dependency>
 
 			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>1.10.0</version>
+			</dependency>
+
+			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-bom</artifactId>
 				<version>${hapi_version}</version>


### PR DESCRIPTION
Until there is a new version of the hapi-fhir-jpaserver-starter we need to force version 1.10.0 of Apache Commons Text
