### PR TITLE
Feature cql 849

### DIFF
--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksProperties.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/CdsHooksProperties.java
@@ -48,6 +48,16 @@ public class CdsHooksProperties {
 			this.expandValueSets = expandValueSets;
 		}
 
+		private Integer queryBatchThreshold;
+
+		public Integer getQueryBatchThreshold() {
+			return queryBatchThreshold;
+		}
+
+		public void setQueryBatchThreshold(Integer queryBatchThreshold) {
+			this.queryBatchThreshold = queryBatchThreshold;
+		}
+
 		private SearchStyleEnum searchStyle;
 
 		public SearchStyleEnum getSearchStyle() {

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/dstu3/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/dstu3/CdsHooksServlet.java
@@ -199,6 +199,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 		logger.info("cds-hooks hook instance: {}", request.hookInstance);
 		logger.info("cds-hooks maxCodesPerQuery: {}", this.getProviderConfiguration().getMaxCodesPerQuery());
 		logger.info("cds-hooks expandValueSets: {}", this.getProviderConfiguration().getExpandValueSets());
+		logger.info("cds-hooks queryBatchThreshold: {}", this.getProviderConfiguration().getQueryBatchThreshold());
 		logger.info("cds-hooks searchStyle: {}", this.getProviderConfiguration().getSearchStyle());
 		logger.info("cds-hooks prefetch maxUriLength: {}", this.getProviderConfiguration().getMaxUriLength());
 		logger.info("cds-hooks local server address: {}", myAppProperties.getServer_address());

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
@@ -7,18 +7,18 @@ import ca.uhn.fhir.rest.api.SearchStyleEnum;
 
 public class ProviderConfiguration {
 
-	public static final ProviderConfiguration DEFAULT_PROVIDER_CONFIGURATION = new ProviderConfiguration(true, 64,
-			SearchStyleEnum.GET, 8000, false, 5);
+	public static final ProviderConfiguration DEFAULT_PROVIDER_CONFIGURATION = new ProviderConfiguration(true, null,
+			SearchStyleEnum.GET, 8000, false, null);
 
-	private int maxCodesPerQuery;
+	private Integer maxCodesPerQuery;
 	private SearchStyleEnum searchStyle;
 	private boolean expandValueSets;
-	private int queryBatchThreshold;
+	private Integer queryBatchThreshold;
 	private int maxUriLength;
 	private boolean cqlLoggingEnabled;
 
-	public ProviderConfiguration(boolean expandValueSets, int maxCodesPerQuery, SearchStyleEnum searchStyle,
-			int maxUriLength, boolean cqlLoggingEnabled, int queryBatchThreshold) {
+	public ProviderConfiguration(boolean expandValueSets, Integer maxCodesPerQuery, SearchStyleEnum searchStyle,
+			int maxUriLength, boolean cqlLoggingEnabled, Integer queryBatchThreshold) {
 		this.maxCodesPerQuery = maxCodesPerQuery;
 		this.searchStyle = searchStyle;
 		this.expandValueSets = expandValueSets;

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/providers/ProviderConfiguration.java
@@ -8,21 +8,23 @@ import ca.uhn.fhir.rest.api.SearchStyleEnum;
 public class ProviderConfiguration {
 
 	public static final ProviderConfiguration DEFAULT_PROVIDER_CONFIGURATION = new ProviderConfiguration(true, 64,
-			SearchStyleEnum.GET, 8000, false);
+			SearchStyleEnum.GET, 8000, false, 5);
 
 	private int maxCodesPerQuery;
 	private SearchStyleEnum searchStyle;
 	private boolean expandValueSets;
+	private int queryBatchThreshold;
 	private int maxUriLength;
 	private boolean cqlLoggingEnabled;
 
 	public ProviderConfiguration(boolean expandValueSets, int maxCodesPerQuery, SearchStyleEnum searchStyle,
-			int maxUriLength, boolean cqlLoggingEnabled) {
+			int maxUriLength, boolean cqlLoggingEnabled, int queryBatchThreshold) {
 		this.maxCodesPerQuery = maxCodesPerQuery;
 		this.searchStyle = searchStyle;
 		this.expandValueSets = expandValueSets;
 		this.maxUriLength = maxUriLength;
 		this.cqlLoggingEnabled = cqlLoggingEnabled;
+		this.queryBatchThreshold = queryBatchThreshold;
 	}
 
 	public ProviderConfiguration(CdsHooksProperties cdsProperties, CqlProperties cqlProperties) {
@@ -30,6 +32,7 @@ public class ProviderConfiguration {
 		this.maxCodesPerQuery = cdsProperties.getFhirServer().getMaxCodesPerQuery();
 		this.searchStyle = cdsProperties.getFhirServer().getSearchStyle();
 		this.maxUriLength = cdsProperties.getPrefetch().getMaxUriLength();
+		this.queryBatchThreshold = cdsProperties.getFhirServer().getQueryBatchThreshold();
 		this.cqlLoggingEnabled = cqlProperties.getOptions().getCqlEngineOptions().isDebugLoggingEnabled();
 	}
 
@@ -44,6 +47,8 @@ public class ProviderConfiguration {
 	public boolean getExpandValueSets() {
 		return this.expandValueSets;
 	}
+
+	public int getQueryBatchThreshold() { return this.queryBatchThreshold; }
 
 	public int getMaxUriLength() {
 		return this.maxUriLength;

--- a/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
+++ b/plugin/cds-hooks/src/main/java/org/opencds/cqf/ruler/cdshooks/r4/CdsHooksServlet.java
@@ -202,6 +202,7 @@ public class CdsHooksServlet extends HttpServlet implements DaoRegistryUser {
 		logger.info("cds-hooks hook instance: {}", request.hookInstance);
 		logger.info("cds-hooks maxCodesPerQuery: {}", this.getProviderConfiguration().getMaxCodesPerQuery());
 		logger.info("cds-hooks expandValueSets: {}", this.getProviderConfiguration().getExpandValueSets());
+		logger.info("cds-hooks queryBatchThreshold: {}", this.getProviderConfiguration().getQueryBatchThreshold());
 		logger.info("cds-hooks searchStyle: {}", this.getProviderConfiguration().getSearchStyle());
 		logger.info("cds-hooks prefetch maxUriLength: {}", this.getProviderConfiguration().getMaxUriLength());
 		logger.info("cds-hooks local server address: {}", myAppProperties.getServer_address());

--- a/plugin/cds-hooks/src/main/resources/application.yaml
+++ b/plugin/cds-hooks/src/main/resources/application.yaml
@@ -5,6 +5,7 @@ hapi:
          fhirserver:
             expandValueSets: true
             maxCodesPerQuery: 64
+            queryBatchThreshold: 5
             searchStyle: GET
          prefetch:
             maxUriLength: 8000

--- a/plugin/cql/src/main/java/org/opencds/cqf/ruler/cql/CqlConfig.java
+++ b/plugin/cql/src/main/java/org/opencds/cqf/ruler/cql/CqlConfig.java
@@ -144,6 +144,7 @@ public class CqlConfig {
 				provider.setTerminologyProvider(t);
 				provider.setExpandValueSets(true);
 				provider.setMaxCodesPerQuery(2048);
+				provider.setQueryBatchThreshold(5);
 				provider.setModelResolver(modelResolver);
 			}
 			return new CompositeDataProvider(modelResolver, provider);

--- a/plugin/cql/src/main/java/org/opencds/cqf/ruler/cql/JpaFhirRetrieveProvider.java
+++ b/plugin/cql/src/main/java/org/opencds/cqf/ruler/cql/JpaFhirRetrieveProvider.java
@@ -23,8 +23,7 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 
 /**
  * This class provides an implementation of the cql-engine's RetrieveProvider
- * interface which is used for loading
- * data during CQL evaluation.
+ * interface which is used for loading data during CQL evaluation.
  */
 public class JpaFhirRetrieveProvider extends SearchParamFhirRetrieveProvider implements DaoRegistryUser {
 

--- a/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/r4/provider/DataOperationsProvider.java
+++ b/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/r4/provider/DataOperationsProvider.java
@@ -25,6 +25,7 @@ import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
+import org.opencds.cqf.cql.evaluator.CqlOptions;
 import org.opencds.cqf.cql.evaluator.cql2elm.content.fhir.BundleFhirLibrarySourceProvider;
 import org.opencds.cqf.cql.evaluator.cql2elm.util.LibraryVersionSelector;
 import org.opencds.cqf.cql.evaluator.fhir.adapter.AdapterFactory;
@@ -78,6 +79,9 @@ public class DataOperationsProvider extends DaoRegistryOperationProvider {
 
 	@Autowired
 	CqlTranslatorOptions cqlTranslatorOptions;
+
+	@Autowired
+	CqlOptions cqlOptions;
 
 	@Operation(name = "$data-requirements", idempotent = true, type = Library.class)
 	public Library dataRequirements(@IdParam IdType theId,
@@ -168,10 +172,11 @@ public class DataOperationsProvider extends DaoRegistryOperationProvider {
 		LibraryManager libraryManager = createLibraryManager(library, theRequestDetails);
 		CqlTranslator translator = translateLibrary(library, libraryManager);
 
+		cqlOptions.setCqlTranslatorOptions(cqlTranslatorOptions);
 		// TODO: Pass the server's capability statement
 		// TODO: Enable passing a capability statement as a parameter to the operation
 		return DataRequirements.getModuleDefinitionLibraryR4(libraryManager, translator.getTranslatedLibrary(),
-				cqlTranslatorOptions, searchParameterResolver,
+				cqlOptions, searchParameterResolver,
 				jpaTerminologyProviderFactory.create(theRequestDetails),
 				myModelResolver, null);
 	}
@@ -180,10 +185,12 @@ public class DataOperationsProvider extends DaoRegistryOperationProvider {
 		LibraryManager libraryManager = createLibraryManager(library, theRequestDetails);
 		CqlTranslator translator = translateLibrary(library, libraryManager);
 
+		cqlOptions.setCqlTranslatorOptions(cqlTranslatorOptions);
+
 		// TODO: Pass the server's capability statement
-		// TODO: Enable passing a capabiliity statement as a parameter to the operation
+		// TODO: Enable passing a capability statement as a parameter to the operation
 		return DataRequirements.getModuleDefinitionLibraryR4(measure, libraryManager, translator.getTranslatedLibrary(),
-				cqlTranslatorOptions, searchParameterResolver,
+				cqlOptions, searchParameterResolver,
 				jpaTerminologyProviderFactory.create(theRequestDetails),
 				myModelResolver, null);
 	}

--- a/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/utility/DataRequirements.java
+++ b/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/utility/DataRequirements.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.cql.engine.fhir.retrieve.R4FhirQueryGenerator;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.cql.evaluator.CqlOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +100,7 @@ public class DataRequirements {
 	public static org.hl7.fhir.r4.model.Library getModuleDefinitionLibraryR4(org.hl7.fhir.r4.model.Measure measureToUse,
 			LibraryManager libraryManager,
 			CompiledLibrary translatedLibrary,
-			CqlTranslatorOptions options,
+			CqlOptions cqlOptions,
 			SearchParameterResolver searchParameterResolver,
 			TerminologyProvider terminologyProvider,
 			ModelResolver modelResolver,
@@ -111,28 +112,28 @@ public class DataRequirements {
 		Set<String> expressionList = getExpressions(r5Measure);
 		DataRequirementsProcessor dqReqTrans = new DataRequirementsProcessor();
 		org.hl7.fhir.r5.model.Library effectiveDataRequirements = dqReqTrans.gatherDataRequirements(libraryManager,
-				translatedLibrary, options, expressionList, true);
+				translatedLibrary, cqlOptions.getCqlTranslatorOptions(), expressionList, true);
 		org.hl7.fhir.r4.model.Library r4EffectiveDataRequirements = (org.hl7.fhir.r4.model.Library) versionConvertor_40_50
 				.convertResource(effectiveDataRequirements);
 		r4EffectiveDataRequirements = addDataRequirementFhirQueries(r4EffectiveDataRequirements, searchParameterResolver,
-				terminologyProvider, modelResolver, capStatement);
+				terminologyProvider, modelResolver, cqlOptions, capStatement);
 		return r4EffectiveDataRequirements;
 	}
 
 	public static org.hl7.fhir.r4.model.Library getModuleDefinitionLibraryR4(LibraryManager libraryManager,
 			CompiledLibrary translatedLibrary,
-			CqlTranslatorOptions options,
+			CqlOptions cqlOptions,
 			SearchParameterResolver searchParameterResolver,
 			TerminologyProvider terminologyProvider,
 			ModelResolver modelResolver,
 			IBaseConformance capStatement) {
 		org.hl7.fhir.r5.model.Library libraryR5 = getModuleDefinitionLibraryR5(libraryManager, translatedLibrary,
-				options);
+			cqlOptions.getCqlTranslatorOptions());
 		VersionConvertor_40_50 versionConvertor_40_50 = new VersionConvertor_40_50(new BaseAdvisor_40_50());
 		org.hl7.fhir.r4.model.Library libraryR4 = (org.hl7.fhir.r4.model.Library) versionConvertor_40_50
 				.convertResource(libraryR5);
 		libraryR4 = addDataRequirementFhirQueries(libraryR4, searchParameterResolver, terminologyProvider, modelResolver,
-				capStatement);
+				cqlOptions, capStatement);
 		return libraryR4;
 	}
 
@@ -153,12 +154,20 @@ public class DataRequirements {
 			SearchParameterResolver searchParameterResolver,
 			TerminologyProvider terminologyProvider,
 			ModelResolver modelResolver,
+			CqlOptions cqlOptions,
 			IBaseConformance capStatement) {
 		List<org.hl7.fhir.r4.model.DataRequirement> dataReqs = library.getDataRequirement();
 
 		try {
 			BaseFhirQueryGenerator fhirQueryGenerator = new R4FhirQueryGenerator(searchParameterResolver,
 					terminologyProvider, modelResolver);
+			// TODO: ExpandValueSets needs to come from configuration
+			fhirQueryGenerator.setExpandValueSets(true);
+			fhirQueryGenerator.setMaxCodesPerQuery(cqlOptions.getCqlEngineOptions().getMaxCodesPerQuery());
+			if (cqlOptions.getCqlEngineOptions().getPageSize() != null) {
+				fhirQueryGenerator.setPageSize(cqlOptions.getCqlEngineOptions().getPageSize());
+			}
+			fhirQueryGenerator.setQueryBatchThreshold(cqlOptions.getCqlEngineOptions().getQueryBatchThreshold());
 
 			Map<String, Object> contextValues = new HashMap<String, Object>();
 			SubjectContext contextValue = getContextForSubject(library.getSubject());

--- a/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/utility/DataRequirements.java
+++ b/plugin/cr/src/main/java/org/opencds/cqf/ruler/cr/utility/DataRequirements.java
@@ -161,13 +161,21 @@ public class DataRequirements {
 		try {
 			BaseFhirQueryGenerator fhirQueryGenerator = new R4FhirQueryGenerator(searchParameterResolver,
 					terminologyProvider, modelResolver);
-			// TODO: ExpandValueSets needs to come from configuration
-			fhirQueryGenerator.setExpandValueSets(true);
-			fhirQueryGenerator.setMaxCodesPerQuery(cqlOptions.getCqlEngineOptions().getMaxCodesPerQuery());
+
 			if (cqlOptions.getCqlEngineOptions().getPageSize() != null) {
 				fhirQueryGenerator.setPageSize(cqlOptions.getCqlEngineOptions().getPageSize());
 			}
-			fhirQueryGenerator.setQueryBatchThreshold(cqlOptions.getCqlEngineOptions().getQueryBatchThreshold());
+			fhirQueryGenerator.setExpandValueSets(cqlOptions.getCqlEngineOptions().shouldExpandValueSets());
+
+			Integer maxCodesPerQuery = cqlOptions.getCqlEngineOptions().getMaxCodesPerQuery();
+			if (maxCodesPerQuery != null && maxCodesPerQuery > 0) {
+				fhirQueryGenerator.setMaxCodesPerQuery(cqlOptions.getCqlEngineOptions().getMaxCodesPerQuery());
+			}
+
+			Integer queryBatchThreshold = cqlOptions.getCqlEngineOptions().getQueryBatchThreshold();
+			if (queryBatchThreshold != null && queryBatchThreshold > 0) {
+				fhirQueryGenerator.setQueryBatchThreshold(cqlOptions.getCqlEngineOptions().getQueryBatchThreshold());
+			}
 
 			Map<String, Object> contextValues = new HashMap<String, Object>();
 			SubjectContext contextValue = getContextForSubject(library.getSubject());

--- a/server/src/main/resources/application.yaml
+++ b/server/src/main/resources/application.yaml
@@ -32,6 +32,10 @@ hapi:
          engine:
             # debug_logging_enabled: false
             options: "EnableExpressionCaching"
+#            max_codes_per_query: 64
+#            query_batch_threshold: 10
+
+
          # use_embedded_libraries: true
          # translator:
          #    analyzeDataRequirements: false
@@ -96,8 +100,9 @@ hapi:
       cdshooks:
          enabled: true
          fhirserver:
-            expandValueSets: true
-            maxCodesPerQuery: 64
+#            expandValueSets: true
+#            maxCodesPerQuery: 64
+#            queryBatchThreshold: 10
             searchStyle: GET
          prefetch:
             maxUriLength: 8000


### PR DESCRIPTION
Added the queryBatchThreshold configuration point. Made the DataOperationsProvider and DataRequirements aware of the configuration so that it can be passed to the FhirQueryGenerator.